### PR TITLE
tooling: adds simpler example, .gitignore: exclude output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+profile-*
+.__browserify_string_empty.js

--- a/examples/simple/simple.js
+++ b/examples/simple/simple.js
@@ -1,0 +1,17 @@
+'use strict'
+let count = 0, max = 10, res = 0
+
+console.log('Starting process with simple example.');
+setTimeout(()=>{
+  setInterval(()=>{
+    res += 1
+    count++
+    console.log(res);
+
+    if (count >= max) {
+      console.log('Process exited now.');
+      return process.exit()
+    }
+
+  }, 10)
+}, 500)


### PR DESCRIPTION
Two minor nits:
* it was a little easier to have (tracing unrelated) testing with a simpler example. This commit adds one.
* also IDE experience was a little nicer when output was excluded

I can separate those of course, but they seemed too small at the time.