### PR TITLE
use env-string to inline envs for better xplatform support

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const debug = require('debug')('0x')
 const { join, isAbsolute, relative } = require('path')
 const fs = require('fs')
 const execspawn = require('execspawn')
+const envString = require('env-string')
 const validate = require('./lib/validate')(require('./schema.json'))
 const traceStacksToTicks = require('./lib/trace-stacks-to-ticks')
 const v8LogToTicks = require('./lib/v8-log-to-ticks')
@@ -52,8 +53,9 @@ async function zeroEks (args) {
   return file
 
   function spawnOnPort (port) {
-    process.env.PORT = '' + port
-    execspawn(args.onPort, {stdio: 'inherit'})
+    const env = Object.assign({}, process.env, {PORT: '' + port})
+    const script = envString(args.onPort, env)
+    execspawn(script, {stdio: 'inherit', env})
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "debounce": "^1.1.0",
     "debug": "^2.2.0",
     "end-of-stream": "^1.1.0",
+    "env-string": "^1.0.0",
     "execspawn": "^1.0.1",
     "has-unicode": "^2.0.1",
     "hsl-to-rgb-for-reals": "^1.1.0",


### PR DESCRIPTION
makes `$PORT` work everywhere (before windows users had to do `%PORT%` and unix'ers `$PORT`. We still set the env so `%PORT%` is still supported if you really want to