### PR TITLE
Safely parse large trace stacks files

### DIFF
--- a/lib/trace-stacks-to-ticks.js
+++ b/lib/trace-stacks-to-ticks.js
@@ -4,12 +4,25 @@ const fs = require('fs')
 
 module.exports = traceStacksToTicks
 
+function splitBufferOnNewlines (buf) {
+  const splitChar = '\n'
+  let lines = []
+  let searchStart = 0
+  let newlineIx
+  while ((newlineIx = buf.indexOf(splitChar, searchStart)) !== -1) {
+    lines.push(buf.toString('utf8', searchStart, newlineIx))
+    searchStart = newlineIx + 1
+  }
+
+  return lines
+}
+
 function traceStacksToTicks (stacksPath) {
   const header = /(.+):(.+): ?$/
-  var n = -1
-  const stacks = fs.readFileSync(stacksPath)
-    .toString()
-    .split('\n')
+  let n = -1
+
+  /* File size might exceed JS maximum string length, so cannot toString() directly. */
+  const stacks = splitBufferOnNewlines(fs.readFileSync(stacksPath))
     .reduce((stacks, line) => {
       if (header.test(line)) {
         n += 1


### PR DESCRIPTION
Problem:
If the file with trace stacks is larger than the maximum string length,
then traceStacksToTicks chokes on a call to toString.

Solution:
Split buffer on newlines via repeated indexOf rather than via
buf.toString.split('\n')

Test:
I ran assert.deepEqual to compare the stacks generated by the
old and new approaches. It said they were equivalent.

Fixes: #120