### PR TITLE
Style fixes

### DIFF
--- a/visualizer/cmp/graph.js
+++ b/visualizer/cmp/graph.js
@@ -3,7 +3,7 @@
 module.exports = (render) => Object.assign(() => render`
   <chart 
     class='db overflow-y-scroll overflow-x-hidden relative' 
-    style='padding-left: 5%; padding-right: 5%; height: calc(100% - 66px)'
+    style='padding-left: 5%; padding-right: 5%; height: calc(100vh - 66px)'
   >
   </chart>
 `, { v8cats })

--- a/visualizer/cmp/key.js
+++ b/visualizer/cmp/key.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = (render) => ({colors, enableOptUnopt}) => render`
-  <div id=key class='absolute dn db-l' style="top: 0.5em; right: 234px;">
+  <div id=key class='fr dn db-l mr1'>
     <div class='fl' style="margin-right: 5px;">cold</div>
     <div class='fl' style="background: ${colors[0]}; height: 20px; width: 20px; margin-right: 5px;"></div>
     <div class='fl' style="background: ${colors[1]}; height: 20px; width: 20px; margin-right: 5px;"></div>

--- a/visualizer/cmp/search.js
+++ b/visualizer/cmp/search.js
@@ -4,7 +4,7 @@ const debounce = require('debounce')
 
 module.exports = (render) => (action) => {
   const search = render`
-    <input type="search" placeholder="search functions" class='absolute right-0 top-0 mt2 f5 mr1'>
+    <input type="search" placeholder="search functions" class='fr f5 mr1'>
   `
   search.addEventListener('keydown', debounce(({ target }) => action({type: 'key', value: target.value}), 150))
 

--- a/visualizer/cmp/zoom.js
+++ b/visualizer/cmp/zoom.js
@@ -1,8 +1,8 @@
 'use strict'
 
 module.exports = (render) => (action) => render`
-  <div class='absolute dn db-l' style="right: 180px;top:8px"> 
-    <button onclick=${() => action({type: 'out'})}>−</button>
-    <button onclick=${() => action({type: 'in'})}>+</button> 
+  <div class='fr dn db-l h-100 mr1'>
+    <button class='h-100' onclick=${() => action({type: 'out'})}>−</button>
+    <button class='h-100' onclick=${() => action({type: 'in'})}>+</button>
   </div>
 `


### PR DESCRIPTION
- Fixes the height of the graph in FF
  For some reason `height: calc(100% - 66px)` does something totally
  different than `height: 100%`, but with `100vh` the behaviour is the
  same either way. This seems like a FF CSS bug maybe…
- Use floating + margins instead of absolute positions for top bar
  controls
  Default button and input sizes are different across browsers and OSes,
  by using floats + margins the positioning adapts to sizes instead of
  having things drawn on top of each other.

Before

![image](https://user-images.githubusercontent.com/1006268/42270681-c1fd91dc-7f81-11e8-8c26-d1b97a115741.png)


After

![image](https://user-images.githubusercontent.com/1006268/42270462-3b282500-7f81-11e8-9210-0734cc857e23.png)
