### PR TITLE
Use timestamp instead of pid for isolate log for babel-node support

### DIFF
--- a/platform/v8.js
+++ b/platform/v8.js
@@ -24,10 +24,12 @@ module.exports = v8
 async function v8 (args, binary) {
   const { status, outputDir, workingDir, name, onPort } = args
 
+  const timestamp = Number(new Date())
+
   var node = !binary || binary === 'node' ? await pathTo('node') : binary
   var proc = spawn(node, [
     '--prof',
-    `--logfile=%p-v8.log`,
+    `--logfile=${timestamp}-v8.log`,
     '--print-opt-source',
     '-r', path.join(__dirname, '..', 'lib', 'preload', 'redir-stdout'),
     '-r', path.join(__dirname, '..', 'lib', 'preload', 'soft-exit'),
@@ -67,7 +69,7 @@ async function v8 (args, binary) {
 
   debug('moving isolate file into folder')
   const isolateLog = fs.readdirSync(args.workingDir).find(function (f) {
-    return new RegExp(`isolate-0(x)?([0-9A-Fa-f]{2,16})-${proc.pid}-v8.log`).test(f)
+    return new RegExp(`isolate-0(x)?([0-9A-Fa-f]{2,16})-${timestamp}-v8.log`).test(f)
   })
 
   if (!isolateLog) throw Error('no isolate logfile found')


### PR DESCRIPTION
babel-node spawn its own sub-process which generates a isolate log that
0x is not able to locate.

To resolve such a issue, timestamp might be used as a clue for locating
those isolate logs generated with non-standard 0x.

Tested with `0x -o -- babel-node --prof foo.js`.