### PR TITLE
fix signalling on windows

### DIFF
--- a/lib/preload/detect-port.js
+++ b/lib/preload/detect-port.js
@@ -2,11 +2,20 @@
 
 const onListen = require('on-net-listen')
 const fs = require('fs')
+const net = require('net')
 
 onListen(function (addr) {
   this.destroy()
   const port = Buffer.from(addr.port + '')
   fs.writeSync(5, port, 0, port.length)
-  fs.closeSync(5)
+  signal(5, function () {
+    process.exit()
+  })
 })
 
+function signal (fd, cb) {
+  const s = new net.Socket({fd, readable: true, writable: true})
+  s.unref()
+  s.on('error', () => {})
+  s.on('close', cb)
+}

--- a/platform/v8.js
+++ b/platform/v8.js
@@ -49,7 +49,7 @@ async function v8 (args, binary) {
     new Promise((resolve) => process.once('SIGINT', resolve)),
     new Promise((resolve) => proc.once('exit', (code) => resolve(code))),
     ...(onPort ? [new Promise((resolve, reject) => {
-      whenPort.then(() => proc.kill('SIGINT'))
+      whenPort.then(() => proc.stdio[5].destroy())
       whenPort.catch((err) => {
         proc.kill()
         reject(err)


### PR DESCRIPTION
Using childProcess.kill on windows have a ton of issues as its equi of kill -9 on unix. this changes it to use a 'soft signal' instead