### PR TITLE
Stretch height to fit tallest stack

### DIFF
--- a/visualizer/index.js
+++ b/visualizer/index.js
@@ -16,11 +16,15 @@ module.exports = function (trees, opts) {
   const chart = graph()
   const tree = trees.unmerged // default view
   const categorizer = !kernelTracing && graph.v8cats
+  const cellCount = tree.children.map(getDeepest).reduce((prev, next) => Math.max(prev, next), 0)
+  const headerBarOffset = 55
+  const cellHeight = 18.5
   const flamegraph = fg({
     categorizer, 
     tree, 
     exclude: Array.from(exclude), 
-    element: chart
+    element: chart,
+    height: (cellCount * cellHeight) + headerBarOffset
   })
   const { colors } = flamegraph
 
@@ -39,4 +43,11 @@ module.exports = function (trees, opts) {
 
   document.body.appendChild(chart)
   document.body.appendChild(iface)
+}
+
+function getDeepest (node) {
+  if (!node.children) {
+    return 1
+  }
+  return node.children.map(getDeepest).reduce((prev, next) => Math.max(prev, next), 0) + 1
 }


### PR DESCRIPTION
Some stacks end up trimmed because they are taller than the viewport (can be confirmed by zooming out with `-` button)

## Screenshots of scroll-top

Before:
<img width="1680" alt="screen shot 2018-08-08 at 15 30 20" src="https://user-images.githubusercontent.com/10513845/43843726-16f142f6-9b20-11e8-99db-4f45266bb829.png">

After:
<img width="1680" alt="screen shot 2018-08-08 at 15 30 44" src="https://user-images.githubusercontent.com/10513845/43843724-16c95a52-9b20-11e8-9d46-1e978327c5c0.png">


## Screenshots of full scrollable content

Before:
![screencapture-file-users-km-work-bubble-setup-node-clinic-examples-87001-clinic-flame-html-2018-08-08-15_28_43](https://user-images.githubusercontent.com/10513845/43843584-d1eaa288-9b1f-11e8-8de2-8cea32f38dc6.png)

After:
![screencapture-file-users-km-work-bubble-setup-node-clinic-examples-87001-clinic-flame-html-2018-08-08-15_28_16](https://user-images.githubusercontent.com/10513845/43843602-da5e6a30-9b1f-11e8-9b4f-662aeef8624e.png)
