### PR TITLE
Remove duplicated JS from flamegraph.html

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -2,7 +2,6 @@
 
 const path = require('path')
 const browserify = require('browserify')
-const multistream = require('multistream')
 const concat = require('concat-stream')
 const pump = require('pump')
 const debug = require('debug')('0x:render')
@@ -57,11 +56,7 @@ function determineHtmlPath ({name, outputHtml, workingDir, pid, outputDir}) {
 function createBundle () {
   return new Promise((resolve, reject) => {
     pump(
-      multistream([
-        browserify({standalone: 'hsl'}).add(require.resolve('hsl-to-rgb-for-reals')).bundle(),
-        browserify({standalone: 'fg'}).add(require.resolve('d3-fg')).bundle(),
-        browserify({standalone: 'visualizer'}).add(path.resolve(__dirname, '..', 'visualizer')).bundle()
-      ]),
+      browserify({standalone: 'visualizer'}).add(path.resolve(__dirname, '..', 'visualizer')).bundle(),
       concat(resolve),
       (err) => err && reject(err)
     )

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "jsonstream2": "^1.1.1",
     "minimist": "^1.2.0",
     "morphdom": "^2.3.3",
-    "multistream": "^2.1.0",
     "nanohtml": "^1.0.1",
     "on-net-listen": "^1.1.0",
     "opn": "^5.2.0",


### PR DESCRIPTION
Fixes #147

Removing standalone bundles of `hsl-to-rgb-for-reals` and `d3-fg` because the modules are already included in the `../visualizer` bundle.

As a result, the size of `flamegraph.html` from `examples/api.js` decreased roughly from 828 KB to 559 KB.