### PR TITLE
Fix error on resize

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ajv": "^6.0.1",
     "browserify": "^13.0.0",
     "concat-stream": "^1.5.2",
-    "d3-fg": "^6.1.0",
+    "d3-fg": "^6.2.3",
     "debounce": "^1.1.0",
     "debug": "^2.2.0",
     "end-of-stream": "^1.1.0",

--- a/visualizer/index.js
+++ b/visualizer/index.js
@@ -28,7 +28,6 @@ module.exports = function (trees, opts) {
   window.addEventListener('resize', debounce(() => {
     const width = document.body.clientWidth * 0.89
     flamegraph.width(width).update()
-    chart.querySelector('svg').setAttribute('width', width)
   }, 150))
 
   const state = createState({colors, trees, exclude, kernelTracing, title: opts.title})


### PR DESCRIPTION
When I resize the browser window in `flamegraph.html`, I get the following error in console.

```
Uncaught TypeError: Cannot read property 'setAttribute' of null
    at window.addEventListener.debounce (flamegraph.html:11197)
    at later (flamegraph.html:9405)
```

The error happens because the code tries to resize an `<svg>` element while `d3-fg` doesn't use `<svg>` anymore.

This PR removes the line causing the error. Even without the line, the line above resizes the chart properly.