### PR TITLE
Fix resizing canvas after window resize

### DIFF
--- a/visualizer/index.js
+++ b/visualizer/index.js
@@ -26,8 +26,8 @@ module.exports = function (trees, opts) {
 
   window.addEventListener('resize', debounce(() => {
     const width = document.body.clientWidth * 0.89
+    chart.querySelector('canvas').width = width
     flamegraph.width(width).update()
-    chart.querySelector('svg').setAttribute('width', width)
   }, 150))
 
   const state = createState({colors, trees, exclude, kernelTracing, title: opts.title})


### PR DESCRIPTION
This was still trying to resize the svg instead of the canvas.

The setAttribute and update() lines need to be flipped because setting
the canvas width clears the contents; need a redraw afterward.