### PR TITLE
Direct stack frame #-links + history

### DIFF
--- a/visualizer/actions.js
+++ b/visualizer/actions.js
@@ -16,8 +16,11 @@ function createActions ({flamegraph, state}, emit) {
 
   function focusNode () {
     const save = pushState()
-    return (id) => {
-      state.focusedNodeId = id
+    return (node) => {
+      const { merged } = state.control
+      const { nodesToIds } = merged ? mergedTags : unmergedTags
+
+      state.focusedNodeId = nodesToIds.get(node)
       save()
     }
   }
@@ -123,10 +126,9 @@ function createActions ({flamegraph, state}, emit) {
     return () => {
       const { merged } = state.control
       const excludeTypes = Array.from(state.typeFilters.exclude)
-      const { nodesToIds } = merged ? mergedTags : unmergedTags
       const historyState = {
         merged,
-        nodeId: nodesToIds.get(state.focusedNodeId),
+        nodeId: state.focusedNodeId,
         excludeTypes
       }
       window.history.pushState(historyState, '', `#${stringifyHistoryState(historyState)}`)

--- a/visualizer/actions.js
+++ b/visualizer/actions.js
@@ -192,6 +192,7 @@ function tagNodesWithIds (data) {
   }
 }
 
-function stringifyHistoryState ({ merged, nodeId, excludeTypes }) {
-  return `${merged ? 'merged' : 'unmerged'}-${nodeId}-${excludeTypes.join('+')}`
+function stringifyHistoryState (state) {
+  // Just use JSON I guess
+  return JSON.stringify(state)
 }

--- a/visualizer/index.js
+++ b/visualizer/index.js
@@ -36,8 +36,10 @@ module.exports = function (trees, opts) {
   window.addEventListener('popstate', (event) => {
     userZoom = false
     jumpToState(event.state || {
-      merged: true,
-      nodeId: 0
+      // No hash anymore, jump to root node (0) but don't change settings
+      merged: state.control.merged,
+      exclude: Array.from(state.filterTypes.exclude),
+      nodeId: 0,
     })
   })
 
@@ -72,5 +74,6 @@ function parseHistoryState (str) {
   const parts = str.replace(/^#/, '').split('-')
   const merged = parts[0] === 'merged'
   const nodeId = parseInt(parts[1], 10)
-  return { merged, nodeId }
+  const excludeTypes = parts[2].split('+')
+  return { merged, nodeId, excludeTypes }
 }

--- a/visualizer/index.js
+++ b/visualizer/index.js
@@ -62,7 +62,7 @@ module.exports = function (trees, opts) {
   document.body.appendChild(iface)
 
   if (window.location.hash) {
-    const st = parseHistoryState(window.location.hash)
+    const st = parseHistoryState(window.location.hash.slice(1))
     if (st) {
       userZoom = false
       jumpToState(st)
@@ -71,9 +71,10 @@ module.exports = function (trees, opts) {
 }
 
 function parseHistoryState (str) {
-  const parts = str.replace(/^#/, '').split('-')
-  const merged = parts[0] === 'merged'
-  const nodeId = parseInt(parts[1], 10)
-  const excludeTypes = parts[2].split('+')
-  return { merged, nodeId, excludeTypes }
+  try {
+    return JSON.parse(str)
+  } catch (err) {
+    // Just ignore if someone used an incorrect hash
+    return null
+  }
 }

--- a/visualizer/index.js
+++ b/visualizer/index.js
@@ -31,14 +31,14 @@ module.exports = function (trees, opts) {
       return
     }
 
-    pushState(d)
+    focusNode(d)
   })
   window.addEventListener('popstate', (event) => {
     userZoom = false
     jumpToState(event.state || {
       // No hash anymore, jump to root node (0) but don't change settings
       merged: state.control.merged,
-      exclude: Array.from(state.filterTypes.exclude),
+      exclude: Array.from(state.typeFilters.exclude),
       nodeId: 0,
     })
   })
@@ -55,8 +55,8 @@ module.exports = function (trees, opts) {
     morphdom(iface, ui({state, actions}))
   })
   const iface = ui({state, actions})
+  const focusNode = actions.focusNode()
   const jumpToState = actions.jumpToState()
-  const pushState = actions.pushState()
 
   document.body.appendChild(chart)
   document.body.appendChild(iface)

--- a/visualizer/index.js
+++ b/visualizer/index.js
@@ -39,7 +39,7 @@ module.exports = function (trees, opts) {
       // No hash anymore, jump to root node (0) but don't change settings
       merged: state.control.merged,
       excludeTypes: Array.from(state.typeFilters.exclude),
-      nodeId: 0,
+      nodeId: 0
     })
   })
 

--- a/visualizer/index.js
+++ b/visualizer/index.js
@@ -38,7 +38,7 @@ module.exports = function (trees, opts) {
     jumpToState(event.state || {
       // No hash anymore, jump to root node (0) but don't change settings
       merged: state.control.merged,
-      exclude: Array.from(state.typeFilters.exclude),
+      excludeTypes: Array.from(state.typeFilters.exclude),
       nodeId: 0,
     })
   })

--- a/visualizer/index.js
+++ b/visualizer/index.js
@@ -72,7 +72,7 @@ module.exports = function (trees, opts) {
 
 function parseHistoryState (str) {
   try {
-    return JSON.parse(str)
+    return JSON.parse(decodeURIComponent(str))
   } catch (err) {
     // Just ignore if someone used an incorrect hash
     return null

--- a/visualizer/state.js
+++ b/visualizer/state.js
@@ -5,6 +5,7 @@ const { colorHash } = require('d3-fg')
 
 module.exports = ({colors, trees, exclude, merged = false, kernelTracing, title}) => ({
   trees,
+  focusedNodeId: null,
   key: {
     colors: [
       colorHash({top: 0, name: 'cold'}, 1, 100),


### PR DESCRIPTION
A flame graph made with this version is viewable at https://upload.clinicjs.org/public/509680025b4cc97cec5a7e2eaacdb90c10c5585ba70b7bb8656bc3985db468c1/8353.clinic-flame.html (see below for direct stack frame link examples)

This patch stores the current focused node in the URL hash, so you can
link to a specific stack. It does that by assigning each node an ID on
load. It's a counter that does a preorder traversal, this is a safe way
to do it because the data that is used is static, stack frame 352 will
be the same regardless of who opens the file.

It also implements the back/forward buttons using the `pushState()` API.
Only the merged/unmerged setting, the type visibility settings (c++, v8, etc)
and the focused node ID are stored, because those must be known in order
to show the correct node. Other stuff like search / tiers / whatnot is not
stored, I think that's less important anyway, if necessary people can just
use a direct stack frame link and tell the recipient that they should press
some buttons to get the perfect view. A tiny stack frame is hard to find but
a big button is not :)

The hash is read on load, elsewhere the history API is
used—`pushState()` and `onpopstate` are a little easier to deal with
than `hash` and `onhashchange`. (onpopstate is _only_ triggered by user
action for example so we don't have to check if we just pushState()d.)

Requires https://github.com/davidmarkclements/d3-fg/pull/7

## Examples

Direct link to a random stack frame I picked: https://upload.clinicjs.org/public/509680025b4cc97cec5a7e2eaacdb90c10c5585ba70b7bb8656bc3985db468c1/8353.clinic-flame.html#unmerged-2368-regexp+init+v8+native+cpp

Direct link to a C++ stack frame: https://upload.clinicjs.org/public/509680025b4cc97cec5a7e2eaacdb90c10c5585ba70b7bb8656bc3985db468c1/8353.clinic-flame.html#unmerged-2202-regexp+init+v8+native (would be hidden on load by default)

Direct link to a stack frame in the merged view: https://upload.clinicjs.org/public/509680025b4cc97cec5a7e2eaacdb90c10c5585ba70b7bb8656bc3985db468c1/8353.clinic-flame.html#merged-727-regexp+init+v8+native+cpp (default view is unmerged)