### PR TITLE
Send SIGTERM to subprocess on second Ctrl+C

### DIFF
--- a/examples/rest-api/package.json
+++ b/examples/rest-api/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "wrk -d 120 -c 100 http://localhost:3000/a & wrk -d 120 -c 100 http://localhost:3000/b & wrk -d 120 -c 100 http://localhost:3000/c"
+    "test": "wrk -d 5 -c 100 http://localhost:3000/a & wrk -d 5 -c 100 http://localhost:3000/b & wrk -d 5 -c 100 http://localhost:3000/c"
   },
   "author": "David Mark Clements",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "stress-rest-example": "cd examples/rest-api && npm test",
+    "start": "./cmd.js --on-port 'npm run stress-rest-example' -- node examples/rest-api",
     "lint": "standard"
   },
   "repository": {

--- a/platform/v8.js
+++ b/platform/v8.js
@@ -43,11 +43,6 @@ async function v8 (args, binary) {
 
   proc.stdio[3].pipe(process.stdout)
 
-  const forceClose = () => {
-    status('Force closing subprocess...')
-    proc.kill()
-  }
-
   let closeTimer
   let softClosed = false
   const softClose = () => {
@@ -62,6 +57,10 @@ async function v8 (args, binary) {
 
     onsigint = forceClose
     process.once('SIGINT', onsigint)
+  }
+  const forceClose = () => {
+    status('Force closing subprocess...')
+    proc.kill()
   }
 
   let onsigint = softClose


### PR DESCRIPTION
This fixes an issue where, if the subprocess was stuck on a sync operation, pressing Ctrl+C would generate a flame graph and exit 0x, but the subprocess would keep spinning on in the background.

I used:

```js
// loop.js
while (true);
```
```bash
./cmd.js loop.js
```

Previously, doing Ctrl+C would generate the flame graph, and then 0x would keep running afterward because the subprocess hadn't ended. Sending another Ctrl+C would terminate 0x, as it no longer has a SIGINT handler, but the subprocess would keep running.

With this patch, we catch two SIGINTs—the first uses the `stdio[5].destroy()` soft-close mechanism like before, and the second sends a SIGTERM to the subprocess. 0x suggests sending a second Ctrl+C if soft-closing takes a very long time.
As a last-resort measure, a SIGTERM is also sent to the subprocess when 0x itself exits. (perhaps this should just do `proc.kill()` to be absolutely sure?) This can happen when using --on-port because the flamegraph starts being generated as soon as the --on-port process ends, rather than when the process being monitored ends. (hmm, perhaps it should wait for the monitored process to end too?)

<strike>This branch is a bit of a mess because I was trying and failing to address #136. I'll squash it in a bit.</strike>done. Note this patch does not solve #136.