### PR TITLE
Throw error if a cluster subprocess is forked

### DIFF
--- a/lib/preload/no-cluster.js
+++ b/lib/preload/no-cluster.js
@@ -1,0 +1,5 @@
+const cluster = require('cluster')
+
+cluster.on('fork', () => {
+  throw new Error('0x does not support clustering.')
+})

--- a/platform/v8.js
+++ b/platform/v8.js
@@ -29,6 +29,7 @@ async function v8 (args, binary) {
     '--prof',
     `--logfile=%p-v8.log`,
     '--print-opt-source',
+    '-r', path.join(__dirname, '..', 'lib', 'preload', 'no-cluster'),
     '-r', path.join(__dirname, '..', 'lib', 'preload', 'redir-stdout'),
     '-r', path.join(__dirname, '..', 'lib', 'preload', 'soft-exit'),
     ...(onPort ? ['-r', path.join(__dirname, '..', 'lib', 'preload', 'detect-port.js')] : [])


### PR DESCRIPTION
0x doesn't support multi processes.

I used the 'fork' event because it's easier than intercepting `require`
and this way it allows requiring but not using `cluster`.
If the subprocess does `try { cluster.fork() }` this won't crash, but
that's probably fine? Same if the subprocess has an 'uncaughtException'
handler.

Ex:

```
➜  ./cmd.js cluster.js
🔥  Profiling/home/goto-bus-stop/Code/nearform/0x/lib/preload/no-cluster.js:4
  throw new Error('0x does not support clustering.')
  ^
Error: 0x does not support clustering.
    at EventEmitter.cluster.on (/home/goto-bus-stop/Code/nearform/0x/lib/preload/no-cluster.js:4:9)
    at EventEmitter.emit (events.js:182:13)
    at emitForkNT (internal/cluster/master.js:226:11)
    at process._tickCallback (internal/process/next_tick.js:63:19)
    at Function.Module.runMain (internal/modules/cjs/loader.js:745:11)
    at startup (internal/bootstrap/node.js:266:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:596:3)
🚫  Target subprocess error, code: 1
```

```js
// cluster.js
const { isMaster, fork } = require('cluster')
if (isMaster) {
  fork()
} else {
  console.log('hi')
}
```