### PR TITLE
Change process.stdout.write switcharoo to a full net.Socket instance

### DIFF
--- a/lib/preload/redir-stdout.js
+++ b/lib/preload/redir-stdout.js
@@ -1,14 +1,13 @@
 'use strict'
-const fs = require('fs')
-process.stdout.write = ((write) => (chunk, encoding, cb) => {
-  if (typeof chunk !== 'string' && !(chunk instanceof Buffer)) {
-    throw new TypeError(
-      'Invalid data, chunk must be a string or buffer, not ' + typeof chunk);
-  }
-  if (typeof encoding === 'function') {
-    cb = encoding
-  }
-  fs.writeSync(3, chunk)
-  if (typeof cb === 'function') cb()
-  return true
-})(process.stdout.write.bind(process.stdout))
+const net = require('net')
+
+const socket = new net.Socket({
+  fd: 3,
+  readable: false,
+  writable: true
+})
+Object.defineProperty(process, 'stdout', {
+  configurable: true,
+  enumerable: true,
+  get: () => socket
+})


### PR DESCRIPTION
No matter how you write to stdout, this should catch it!
The `defineProperty` call uses the same options as the default `process.stdout`.