### PR TITLE
Allow 0x to create output in a subfolder of a new folder

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -32,7 +32,7 @@ function spawnOnPort (cmd, port) {
   return new Promise((resolve, reject) => {
     sp.on('exit', (code, signal) => {
       if (code === 0 || code === null) resolve(code, signal)
-      else reject(Object.assign(Error(`onPort command failed with code: ${code}`), { code })) 
+      else reject(Object.assign(Error(`onPort command failed with code: ${code}`), { code }))
     })
   })
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -8,6 +8,7 @@ const which = require('which')
 const debug = require('debug')('0x')
 const execSpawn = require('execspawn')
 const envString = require('env-string')
+const makeDir = require('make-dir')
 
 module.exports = {
   getTargetFolder, tidy, pathTo, isSudo, noop, spawnOnPort, when
@@ -43,17 +44,7 @@ function getTargetFolder ({outputDir, workingDir, name, pid}) {
     .replace('{name}', name)
 
   const folder = path.resolve(workingDir, name)
-
-  try {
-    fs.accessSync(folder)
-  } catch (e) {
-    if (e.code === 'ENOENT') {
-      fs.mkdirSync(folder)
-    } else {
-      // function is always used within async/await or promise - fine to throw
-      throw e
-    }
-  }
+  makeDir.sync(folder)
 
   return folder
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -38,10 +38,10 @@ function spawnOnPort (cmd, port) {
 }
 
 function getTargetFolder ({outputDir, workingDir, name, pid}) {
-  name = (outputDir || '{pid}.0x').replace('{pid}', pid || 'UNKNOWN_PID')
-    .replace('{timestamp}', Date.now())
-    .replace('{cwd}', workingDir)
-    .replace('{name}', name)
+  name = (outputDir || '{pid}.0x').replace(/{pid}/g, pid || 'UNKNOWN_PID')
+    .replace(/{timestamp}/g, Date.now())
+    .replace(/{cwd}/g, workingDir)
+    .replace(/{name}/g, name)
 
   const folder = path.resolve(workingDir, name)
   makeDir.sync(folder)

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "has-unicode": "^2.0.1",
     "hsl-to-rgb-for-reals": "^1.1.0",
     "jsonstream2": "^1.1.1",
+    "make-dir": "^1.3.0",
     "minimist": "^1.2.0",
     "morphdom": "^2.3.3",
     "nanohtml": "^1.0.1",


### PR DESCRIPTION
This is to allow 0x to put its output in a subdirectory like, for example:

```
./12345.clinic-flame/12345.clinic-flame-0x-data
```

...so that 3rd party tools that use 0x as an API can more neatly separate 0x's output from their own outputs.

This adds a dependency, [`make-dir`](https://www.npmjs.com/package/make-dir), to handle recursive directory creation. It's actively maintained and appears more robust and simple than the alternatives.