### PR TITLE
Do not require pathToNodeBinary to be set

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const { sun, linux, windows, v8 } = require('./platform')
 const debug = require('debug')('0x')
 const { join, isAbsolute, relative } = require('path')
 const fs = require('fs')
-const { promisify } = require('util')
 const validate = require('./lib/validate')(require('./schema.json'))
 const traceStacksToTicks = require('./lib/trace-stacks-to-ticks')
 const v8LogToTicks = require('./lib/v8-log-to-ticks')
@@ -19,6 +18,8 @@ module.exports = zeroEks
 async function zeroEks (args) {
   args.name = args.name || 'flamegraph'
   args.status = args.status || noop
+  args.pathToNodeBinary = args.pathToNodeBinary || process.execPath
+
   validate(args)
   const { collectOnly, visualizeOnly, treeDebug, mapFrames } = args
   if (collectOnly && visualizeOnly) {
@@ -28,8 +29,7 @@ async function zeroEks (args) {
   if (visualizeOnly) return visualize(args)
 
   args.title = args.title || `node ${args.argv.join(' ')}`
-  const binary = args.pathToNodeBinary || process.execPath
-  var { ticks, pid, folder, inlined } = await startProcessAndCollectTraceData(args, binary)
+  var { ticks, pid, folder, inlined } = await startProcessAndCollectTraceData(args)
 
   if (treeDebug === true) {
     const tree = await ticksToTree(ticks, args, mapFrames, inlined)
@@ -54,17 +54,17 @@ async function zeroEks (args) {
   }
 }
 
-async function startProcessAndCollectTraceData (args, binary) {
+async function startProcessAndCollectTraceData (args) {
   if (!Array.isArray(args.argv)) {
     throw Error('argv option is required')
   }
   args.name = args.name || 'flamegraph'
 
   switch (args.kernelTracing ? platform : 'v8') {
-    case 'v8': return v8(args, binary)
-    case 'linux': return linux(args, await isSudo(), binary)
+    case 'v8': return v8(args)
+    case 'linux': return linux(args, await isSudo())
     case 'win32': return windows()
-    default: return sun(args, await isSudo(), binary)
+    default: return sun(args, await isSudo())
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ async function zeroEks (args) {
   if (visualizeOnly) return visualize(args)
 
   args.title = args.title || `node ${args.argv.join(' ')}`
-  const binary = args.pathToNodeBinary
+  const binary = args.pathToNodeBinary || process.execPath
   var { ticks, pid, folder, inlined } = await startProcessAndCollectTraceData(args, binary)
 
   if (treeDebug === true) {

--- a/lib/v8-log-to-ticks.js
+++ b/lib/v8-log-to-ticks.js
@@ -45,8 +45,9 @@ function v8LogToTicks (isolateLogPath, node) {
     pump(sp.stderr, through((errMsg, _, cb) => {
       if (ignore.test(errMsg)) {
         cb()
+      } else {
+        cb(errMsg, _, cb)
       }
-      else cb(errMsg, _, cb)
     }), process.stderr)
   }
   return new Promise((resolve, reject) => {

--- a/platform/linux.js
+++ b/platform/linux.js
@@ -16,17 +16,17 @@ const {
 
 module.exports = promisify(linux)
 
-function linux (args, sudo, binary, cb) {
-  const { status, outputDir, workingDir, name, onPort } = args
+function linux (args, sudo, cb) {
+  const { status, outputDir, workingDir, name, onPort, pathToNodeBinary } = args
   var perf = pathTo('perf')
   if (!perf) return void cb(Error('Unable to locate perf - make sure it\'s in your PATH'))
   if (!sudo) {
     status('Stacks are captured using perf(1), which requires sudo access\n')
     return spawn('sudo', ['true'])
-      .on('exit', function () { linux(args, true, binary, cb) })
+      .on('exit', function () { linux(args, true, cb) })
   }
 
-  var node = !binary || binary === 'node' ? pathTo('node') : binary
+  var node = pathToNodeBinary === 'node' ? pathTo('node') : pathToNodeBinary
   var uid = parseInt(Math.random() * 1e9, 10).toString(36)
   var perfdat = '/tmp/perf-' + uid + '.data'
   var kernelTracingDebug = args.kernelTracingDebug

--- a/platform/sun.js
+++ b/platform/sun.js
@@ -17,8 +17,8 @@ const {
 
 module.exports = promisify(sun)
 
-function sun (args, sudo, binary, cb) {
-  const { status, outputDir, workingDir, name, onPort } = args
+function sun (args, sudo, cb) {
+  const { status, outputDir, workingDir, name, onPort, pathToNodeBinary } = args
 
   var dtrace = pathTo('dtrace')
   var profile = require.resolve('perf-sym/profile_1ms.d')
@@ -26,9 +26,9 @@ function sun (args, sudo, binary, cb) {
   if (!sudo) {
     status('Stacks are captured using DTrace, which requires sudo access\n')
     return spawn('sudo', ['true'])
-      .on('exit', function () { sun(args, true, binary, cb) })
+      .on('exit', function () { sun(args, true, cb) })
   }
-  var node = !binary || binary === 'node' ? pathTo('node') : binary
+  var node = pathToNodeBinary === 'node' ? pathTo('node') : pathToNodeBinary
   var kernelTracingDebug = args.kernelTracingDebug
 
   args = Object.assign([

--- a/platform/v8.js
+++ b/platform/v8.js
@@ -21,11 +21,11 @@ const {
 
 module.exports = v8
 
-async function v8 (args, binary) {
-  const { status, outputDir, workingDir, name, onPort } = args
+async function v8 (args) {
+  const { status, outputDir, workingDir, name, onPort, pathToNodeBinary } = args
 
-  var node = !binary || binary === 'node' ? await pathTo('node') : binary
-  var proc = spawn(node, [
+  let node = pathToNodeBinary === 'node' ? await pathTo('node') : pathToNodeBinary
+  let proc = spawn(node, [
     '--prof',
     `--logfile=%p-v8.log`,
     '--print-opt-source',
@@ -133,10 +133,10 @@ async function renameSafe (from, to, tries = 0) {
 }
 
 function collectInliningInfo (sp) {
-  var root
-  var stdoutIsPrintOptSourceOutput = false
-  var lastOptimizedFrame = null
-  var inlined = {}
+  let root
+  let stdoutIsPrintOptSourceOutput = false
+  let lastOptimizedFrame = null
+  let inlined = {}
   pump(sp.stdout, split(), through((s, _, cb) => {
     s += '\n'
 


### PR DESCRIPTION
This was the case when 0x was used in a programatic way.