### PR TITLE
Improve init

### DIFF
--- a/lib/ticks-to-tree.js
+++ b/lib/ticks-to-tree.js
@@ -5,6 +5,8 @@ const { join } = require('path')
 const debug = require('debug')('0x: ticks-to-tree')
 
 const preloadDirRx = RegExp(join(__dirname, 'preload'))
+const internalModuleRegExp = /^.?(?:\(anonymous\)|internalBinding|NativeModule[^ ]*) [^/\\][a-zA-Z0-9_/\\-]+\.js:\d+:\d+$/
+const nodeBootstrapRegExp = / internal\/bootstrap.+\.js:\d+:\d+$/
 
 module.exports = ticksToTree
 
@@ -155,7 +157,7 @@ function ticksToTree (ticks, mapFrames, inlined, binary) {
   return { merged, unmerged }
 }
 
-function labelInitFrames (frames, regExp) {
+function labelInitFrames (frames, loadingFrameRegExp) {
   let foundNodeModule = false
   for (var i = frames.length - 1; i >= 0; i--) {
     const frame = frames[i]
@@ -164,14 +166,14 @@ function labelInitFrames (frames, regExp) {
       frame.isInit = true
     // The last module initialization. This is only Node.js internally.
     // All frames before have to be internal as well.
-    } else if (/^.?(?:\(anonymous\)|internalBinding|NativeModule[^ ]*) [^/\\].+\.js:\d+:\d+$/.test(frame.name) ||
+    } else if (internalModuleRegExp.test(frame.name) ||
                // Node.js 10 has some more bootstrapping code.
-               / internal\/bootstrap.+\.js:\d+:\d+$/.test(frame.name)) {
+               nodeBootstrapRegExp.test(frame.name)) {
       foundNodeModule = true
       frame.name += ' [INIT]'
       frame.isInit = true
     // Loading frames that we matches earlier.
-    } else if (regExp.test(frame.name)) {
+    } else if (loadingFrameRegExp.test(frame.name)) {
       frame.name += ' [INIT]'
       frame.isInit = true
     }

--- a/lib/ticks-to-tree.js
+++ b/lib/ticks-to-tree.js
@@ -27,10 +27,12 @@ function ticksToTree (ticks, mapFrames, inlined, binary) {
 
   // Spawn a file that throws an error to get the loading stack.
   // Then create a regular expression that matches all those files.
-  const child = spawnSync(binary, [join(__dirname, 'loading-stacks')])
-  const stacks = child
-    .stderr
-    .toString()
+  let childStderr = spawnSync(binary, ['--experimental-modules', join(__dirname, 'loading-stacks')]).stderr.toString()
+  if (childStderr.includes('--experimental-modules')) {
+    // Future proof to make sure it works even if the `experimental-modules` flag is removed.
+    childStderr = spawnSync(binary, [join(__dirname, 'loading-stacks')])
+  }
+  const stacks = childStderr
     .match(/ \(.+?:/g)
     .map((e) => e.slice(2))
     .filter((e) => e[0] !== '/' && e[0] !== '\\')


### PR DESCRIPTION
This improves the init detection in two ways: it should stop detecting some native frames as init and it should detect esm modules properly.

I was not able to reproduce the native frames but it should still work properly.

At the moment the esm detection adds the next tick file to the init phase as well (`internal/process/next_tick.js`) and I am somewhat on the edge of having it in INIT or not. Opinions?