### PR TITLE
Fix binary path not found

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,8 @@ async function visualize ({ visualizeOnly, treeDebug, workingDir, title, mapFram
       ticks,
       inlined,
       pid,
-      folder
+      folder,
+      pathToNodeBinary
     })
 
     return file


### PR DESCRIPTION
When running the visulization step the binary path was not passed
through properly. This is now fixed.

Fixes: https://github.com/nearform/node-clinic/issues/62