### PR TITLE
Don't leave isolate log debris if command execution hits error

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,11 @@ async function startProcessAndCollectTraceData (args) {
   args.name = args.name || 'flamegraph'
 
   switch (args.kernelTracing ? platform : 'v8') {
-    case 'v8': return v8(args)
+    case 'v8': return v8(args).catch((err) => {
+      // On error, delete any V8 isolate log left over by the failed process
+      fs.unlinkSync(join(args.workingDir, v8.getIsolateLog(args.workingDir, args.pid)))
+      throw err
+    })
     case 'linux': return linux(args, await isSudo())
     case 'win32': return windows()
     default: return sun(args, await isSudo())

--- a/index.js
+++ b/index.js
@@ -72,8 +72,17 @@ async function startProcessAndCollectTraceData (args) {
 
   switch (args.kernelTracing ? platform : 'v8') {
     case 'v8': return v8(args).catch((err) => {
-      // On error, delete any V8 isolate log left over by the failed process
-      fs.unlinkSync(join(args.workingDir, v8.getIsolateLog(args.workingDir, args.pid)))
+      const logFilePath = join(args.workingDir, v8.getIsolateLog(args.workingDir, args.pid))
+      let message = 'Fatal error in process observed by 0x. Incomplete V8 isolate log '
+
+      if (process.env.DEBUG && process.env.DEBUG.includes('0x')) {
+        message += `is readable for debugging at ${logFilePath}`
+      } else {
+        fs.unlinkSync(logFilePath)
+        message += 'deleted. To preserve these logs, enable debugging (e.g. `DEBUG=0x* 0x my-app.js`)'
+      }
+
+      if (!args.quiet && !args.silent) console.warn(message)
       throw err
     })
     case 'linux': return linux(args, await isSudo())

--- a/platform/v8.js
+++ b/platform/v8.js
@@ -122,9 +122,8 @@ async function v8 (args) {
 
 // Public method so it can be used in external error handlers
 v8.getIsolateLog = function (workingDir, pid) {
-  return fs.readdirSync(workingDir).find(function (f) {
-    return new RegExp(`isolate-0(x)?([0-9A-Fa-f]{2,16})-${pid}-v8.log`).test(f)
-  })
+  const regex = new RegExp(`isolate-0(x)?([0-9A-Fa-f]{2,16})-${pid}-v8.log`)
+  return fs.readdirSync(workingDir).find(regex.test.bind(regex))
 }
 
 async function renameSafe (from, to, tries = 0) {

--- a/platform/v8.js
+++ b/platform/v8.js
@@ -35,6 +35,10 @@ async function v8 (args) {
     stdio: ['ignore', 'pipe', 'inherit', 'pipe', 'ignore', 'pipe']
   })
 
+  // Isolate log is created before command is executed
+  // Add pid to original args object so if command errors, external handlers can clean up
+  args.pid = proc.pid
+
   const inlined = collectInliningInfo(proc)
 
   if (onPort) status('Profiling\n')
@@ -102,9 +106,7 @@ async function v8 (args) {
   status('Process exited, generating flamegraph')
 
   debug('moving isolate file into folder')
-  const isolateLog = fs.readdirSync(args.workingDir).find(function (f) {
-    return new RegExp(`isolate-0(x)?([0-9A-Fa-f]{2,16})-${proc.pid}-v8.log`).test(f)
-  })
+  const isolateLog = v8.getIsolateLog(args.workingDir, proc.pid)
 
   if (!isolateLog) throw Error('no isolate logfile found')
 
@@ -116,6 +118,13 @@ async function v8 (args) {
     pid: proc.pid,
     folder: folder
   }
+}
+
+// Public method so it can be used in external error handlers
+v8.getIsolateLog = function (workingDir, pid) {
+  return fs.readdirSync(workingDir).find(function (f) {
+    return new RegExp(`isolate-0(x)?([0-9A-Fa-f]{2,16})-${pid}-v8.log`).test(f)
+  })
 }
 
 async function renameSafe (from, to, tries = 0) {


### PR DESCRIPTION
Depending on when the error occurs, it's possible for 0x's collect branch using the V8 platform to leave V8 isolate log files lying around in the main working directory after exit. This causes problems such as filling up CI servers of tools that use 0x and have tests for their own handlers for such errors.

To replicate, try running this from the command line. An isolate log file will be created and will persist after completion:

```
0x -- node -e 'setTimeout(() => { fail() }, 1000)'
```

This PR adds a cleanup error handler that deletes any such log if there is an error in the V8 process. Run the above command in this branch while watching the working directory and you should be able to see the isolate log file be created, then deleted after a second when the error is hit.