### PR TITLE
Filter next tick

### DIFF
--- a/lib/random-require.js
+++ b/lib/random-require.js
@@ -1,7 +1,29 @@
 'use strict'
 
-// Initialize console
-console.log // eslint-disable-line no-unused-expressions
-
-Error.stackTraceLimit = Infinity
-throw new Error('Load phase')
+Error.stackTraceLimit = Infinity;
+try {
+  throw new Error();
+} catch (err) {
+  process.nextTick(() => {
+    Error.stackTraceLimit = 2;
+    try {
+      throw new Error();
+    } catch (innerErr) {
+      const filterNextTick = innerErr.stack.split('\n')[2].match(/ \(.+?:/g)[0].slice(2);
+      const stacks = err.stack
+        .match(/ \(.+?:/g)
+        .map((e) => e.slice(2))
+        // Filter Everything that has nothing to do with Node core and next
+        // ticks.
+        .filter((e) => e[0] !== '/' && e[0] !== '\\' && e !== filterNextTick);
+      let regExpStr = '';
+      let separator = '';
+      for (const frame of new Set(stacks)) {
+        regExpStr += `${separator} ${frame.replace(/\\/g, '\\\\').replace(/\./g, '\\.')}\\d+:\\d+`;
+        separator = '|';
+      }
+      regExpStr += '$';
+      console.log(regExpStr);
+    }
+  });
+}

--- a/lib/ticks-to-tree.js
+++ b/lib/ticks-to-tree.js
@@ -3,6 +3,7 @@
 const { spawnSync } = require('child_process')
 const { join } = require('path')
 const debug = require('debug')('0x: ticks-to-tree')
+const assert = require('assert')
 
 const preloadDirRx = RegExp(join(__dirname, 'preload'))
 const internalModuleRegExp = /^.?(?:\(anonymous\)|internalBinding|NativeModule[^ ]*) [^/\\][a-zA-Z0-9_/\\-]+\.js:\d+:\d+$/
@@ -28,23 +29,16 @@ function ticksToTree (ticks, options = {}) {
 
   // Spawn a file that throws an error to get the loading stack.
   // Then create a regular expression that matches all those files.
-  let childStderr = spawnSync(pathToNodeBinary, ['--experimental-modules', join(__dirname, 'loading-stacks')]).stderr.toString()
-  if (childStderr.includes('--experimental-modules')) {
+  const stackArgs = ['--experimental-modules', '--no-warnings', join(__dirname, 'loading-stacks')]
+  let stackChild = spawnSync(pathToNodeBinary, stackArgs)
+  if (stackChild.stderr.toString().includes('--experimental-modules')) {
     // Future proof to make sure it works even if the `experimental-modules` flag is removed.
-    childStderr = spawnSync(pathToNodeBinary, [join(__dirname, 'loading-stacks')])
+    stackArgs.shift()
+    stackChild = spawnSync(pathToNodeBinary, stackArgs)
   }
-  const stacks = childStderr
-    .match(/ \(.+?:/g)
-    .map((e) => e.slice(2))
-    .filter((e) => e[0] !== '/' && e[0] !== '\\')
-  let regExpStr = '('
-  let separator = ''
-  for (const frame of new Set(stacks)) {
-    regExpStr += `${separator} ${frame.replace(/\\/g, '\\\\').replace(/\./g, '\\.')}\\d+:\\d+`
-    separator = '|'
-  }
-  regExpStr += ')$'
-  const regExp = new RegExp(regExpStr)
+  const stackRegExpStr = stackChild.stdout.toString()
+  assert(stackRegExpStr)
+  const regExp = new RegExp(stackRegExpStr)
 
   ticks.forEach((stack) => {
     stack = removeInstrumentationFrames(stack)


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/8822573/46615674-1e6ed100-cb19-11e8-9839-b4c9d5adb4c4.png)

After:
![image](https://user-images.githubusercontent.com/8822573/46615688-26c70c00-cb19-11e8-96a1-5056aaef8f6e.png)

This also moves the main filter logic into the executed function.
This seemed cleaner instead of having to do this in the receiving
part.

Fixes: https://github.com/davidmarkclements/0x/issues/186