### PR TITLE
do not abort on process exit code

### DIFF
--- a/platform/linux.js
+++ b/platform/linux.js
@@ -51,9 +51,7 @@ function linux (args, sudo, cb) {
   }).on('exit', function (code) {
     if (code !== null && code !== 0 && code !== 143 && code !== 130) {
       tidy(args)
-      const err = Error('Tracing subprocess error, code: ' + code)
-      err.code = code
-      cb(Error(err))
+      console.error('Tracing subprocess error, code: ' + code)
       return
     }
     analyze(true)

--- a/platform/sun.js
+++ b/platform/sun.js
@@ -41,9 +41,7 @@ function sun (args, sudo, cb) {
   }).on('exit', function (code) {
     if (code !== 0) {
       tidy()
-      const err = Error('Target subprocess error, code: ' + code)
-      err.code = code
-      cb(err)
+      console.error('Target subprocess error, code: ' + code)
       return
     }
     analyze(true)

--- a/platform/v8.js
+++ b/platform/v8.js
@@ -98,7 +98,7 @@ async function v8 (args) {
   process.removeListener('exit', forceClose)
 
   if (code | 0) {
-    throw Object.assign(Error('Target subprocess error, code: ' + code), { code })
+    console.error('Target subprocess error, code: ' + code)
   }
 
   const folder = getTargetFolder({ outputDir, workingDir, name, pid: proc.pid })


### PR DESCRIPTION
Related to issue #198 and nearform/node-clinic#73

Do not throw on client application termination.
Only report error and continue processing the traces.

Adjusted handler to only report error.
