### PR TITLE
Add onProcessExit option.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -71,6 +71,12 @@ The `frames` parameter is an array of objects containing a `name` property.
 Return `false` to remove the whole stack from the output, or return a 
 modified array to change the output.
 
+#### `onProcessExit` (function)
+
+Called with the exit code when the observed process exits.
+
+Default: ()=>{} (noop)
+
 #### `status` (function)
 
 Is called with status messages from 0x internals - useful for logging

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = zeroEks
 
 async function zeroEks (args) {
   args.name = args.name || 'flamegraph'
+  args.onProcessExit = args.onProcessExit || noop
   args.status = args.status || noop
   args.pathToNodeBinary = args.pathToNodeBinary || process.execPath
   if (args.pathToNodeBinary === 'node') {

--- a/platform/linux.js
+++ b/platform/linux.js
@@ -49,6 +49,7 @@ function linux (args, sudo, cb) {
   ].filter(Boolean).concat(args.argv), {
     stdio: ['ignore', 'inherit', 'inherit', 'ignore', 'ignore', 'pipe']
   }).on('exit', function (code) {
+    args.onProcessExit(code)
     if (code !== null && code !== 0 && code !== 143 && code !== 130) {
       tidy(args)
       console.error('Tracing subprocess error, code: ' + code)

--- a/platform/sun.js
+++ b/platform/sun.js
@@ -39,6 +39,7 @@ function sun (args, sudo, cb) {
   var proc = spawn(pathToNodeBinary, args, {
     stdio: ['ignore', 'inherit', 'inherit', 'ignore', 'ignore', 'pipe']
   }).on('exit', function (code) {
+    args.onProcessExit(code)
     if (code !== 0) {
       tidy()
       console.error('Target subprocess error, code: ' + code)

--- a/platform/v8.js
+++ b/platform/v8.js
@@ -97,6 +97,7 @@ async function v8 (args) {
   process.removeListener('SIGTERM', forceClose)
   process.removeListener('exit', forceClose)
 
+  args.onProcessExit(code)
   if (code | 0) {
     console.error('Target subprocess error, code: ' + code)
   }

--- a/schema.json
+++ b/schema.json
@@ -117,6 +117,7 @@
     "argv": {
       "type": "array",
       "items": {}
-    }
+    },
+    "onProcessExit": {}
   }
 }


### PR DESCRIPTION
Adds a callback that's called ASAP when the profiled process exits. This allows showing the "Analysing data" message early in Flame.