### PR TITLE
Add tests for V8 log and UI classification, fix some Windows bugs and edge cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-  - 6
   - 8
   - 10
   - 11
@@ -9,4 +8,4 @@ os:
   - linux
   - osx
 script:
-  - npm run ci
+  - npm run test

--- a/lib/v8-log-to-ticks.js
+++ b/lib/v8-log-to-ticks.js
@@ -11,6 +11,8 @@ const pump = require('pump')
 const readFile = promisify(fs.readFile)
 const writeFile = promisify(fs.writeFile)
 
+const nodeMajorV = Number(process.versions.node.split('.')[0])
+
 module.exports = wrapper
 
 async function wrapper (isolateLogPath, node) {
@@ -31,10 +33,8 @@ async function prepareForPreprocess (isolateLogPath) {
   return dest
 }
 
+// Fixes node-version-specific issues with isolate log text
 function fixLines (line) {
-  // Fixes node-version-specific issues with isolate log text
-  const nodeMajorV = Number(process.versions.node.split('.')[0])
-
   // Node 11+ are fine
   if (nodeMajorV > 10) return line
 

--- a/lib/v8-log-to-ticks.js
+++ b/lib/v8-log-to-ticks.js
@@ -32,18 +32,39 @@ async function prepareForPreprocess (isolateLogPath) {
 }
 
 function fixLines (line) {
+  // Fixes node-version-specific issues with isolate log text
+  const nodeMajorV = Number(process.versions.node.split('.')[0])
+
+  // Node 11+ are fine
+  if (nodeMajorV > 10) return line
+
   // Work around a bug in Node 10's V8 --preprocess -j that breaks strings containing \\
+  if (nodeMajorV === 10) {
+    // Look for backslashes that aren't escaping a unicode character code, like \\u01a2
+    // Small risk of false positives e.g. is C:\\Users\\u2bfab\\ unicode, or a U2 fan?
+    // So, restrict to basic multilingual (4 char) only. No hieroglyphs or ancient Mayan.
+    const startPath = line.search(/\\(?!u[0-9A-Fa-f]{4})/)
+    if (startPath === -1) return line
 
-  // Look for backslashes that aren't escaping a unicode character code, like \\u01a2
-  // Small risk of false positives e.g. is C:\\Users\\u2bfab\\ unicode, or a U2 fan?
-  // So, catch basic multilingual (4 char) only. No hieroglyphs or ancient Mayan.
-  const startPath = line.search(/\\(?!u[0-9A-Fa-f]{4})/)
-  if (startPath === -1) return line
+    // Replace any \\ that's not part of a unicode escape character
+    const replaceRegex = /\\(?!u[0-9A-Fa-f]{4})/g
+    // \u005c is the unicode escape for the \ char
+    return line.slice(0, startPath) + line.slice(startPath).replace(replaceRegex, '\\u005c')
+  }
 
-  // Replace any \\ that's not part of a unicode escape character
-  const replaceRegex = /\\(?!u[0-9A-Fa-f]{4})/g
-  // \u005c is the unicode escape for the \ char
-  return line.slice(0, startPath) + line.slice(startPath).replace(replaceRegex, '\\u005c')
+  if (nodeMajorV < 10) {
+    // In regexs, Node 8 (and 9) hard-escapes unicode and doubles \\ to \\\\
+    if (!line.match(/^code-creation,RegExp/)) return line
+
+    // Normal buffer decoding, String.normalize() etc doesn't work here, brute force needed
+    const escapedUnicode = line.match(/(\\u[0-9A-Fa-f]{4})+/g)
+    if (escapedUnicode) {
+      for (const match of escapedUnicode) {
+        line = line.replace(match, JSON.parse(`"${match}"`))
+      }
+    }
+    return line.replace(/\\\\/g, '\\')
+  }
 }
 
 function v8LogToTicks (isolateLogPath, node) {
@@ -51,6 +72,8 @@ function v8LogToTicks (isolateLogPath, node) {
   const sp = isJson || spawn(node, [
     '--prof-process', '--preprocess', '-j', isolateLogPath
   ], { stdio: ['ignore', 'pipe', 'pipe'] })
+
+  if (!isJson) sp.stdout.setEncoding('utf8')
 
   const close = isJson ? () => {} : () => sp.kill()
   const srcStream = isJson ? fs.createReadStream(isolateLogPath) : sp.stdout

--- a/lib/v8-log-to-ticks.js
+++ b/lib/v8-log-to-ticks.js
@@ -14,40 +14,36 @@ const writeFile = promisify(fs.writeFile)
 module.exports = wrapper
 
 async function wrapper (isolateLogPath, node) {
-  const filtered = await filterLinesThatAreTooLong(isolateLogPath)
-  const normalised = await normalizeWindowsLog(filtered)
+  const normalised = await prepareForPreprocess(isolateLogPath)
   return v8LogToTicks(normalised, node)
 }
 
-async function normalizeWindowsLog (isolateLogPath) {
-  if (process.platform !== 'win32') return isolateLogPath
-
-  // Only needed because of a V8 tick processor bug that
-  // treats C:(\A...) as an escape sequence when parsing the csv file
-
-  const dest = isolateLogPath + '.normalised'
-  let data = await readFile(isolateLogPath, 'utf8')
-  data = data.split('\n').map(escapePath).join('\n')
-  await writeFile(dest, data)
-  return dest
-}
-
-function escapePath (line) {
-  const startPath = line.indexOf(':\\')
-  if (startPath === -1) return line
-  // \u005c is the unicode escape for the \ char
-  return line.slice(0, startPath) + line.slice(startPath).replace(/([^\\])\\([^\\]|$)/g, '$1\\u005c$2')
-}
-
-// long lines make the --preprocess crash. We are just filtering them beforehand
-// as Node.js 8.12.0 would crash if there is any error in the preprocess script
+// 1. Filter because long lines make the --preprocess crash. Filter them beforehand,
+//    because Node.js 8.12.0 would crash if there is any error in the preprocess script
+// 2. Escape backslashes because V8's --preprocess -j treats \\ as an escape pattern,
+//    garbling Windows paths or regular expression definitions that contain it
 // TODO use streams
-async function filterLinesThatAreTooLong (isolateLogPath) {
-  const dest = isolateLogPath + '.filtered'
-  let data = await readFile(isolateLogPath, 'utf8')
-  data = data.split('\n').filter((s) => s.length < 1024).join('\n')
+async function prepareForPreprocess (isolateLogPath) {
+  const dest = isolateLogPath + '.preprocess-ready'
+  let data = await readFile(isolateLogPath, { encoding: 'utf8' })
+  data = data.split('\n').filter((s) => s.length < 1024).map(fixLines).join('\n')
   await writeFile(dest, data)
   return dest
+}
+
+function fixLines (line) {
+  // Work around a bug in Node 10's V8 --preprocess -j that breaks strings containing \\
+
+  // Look for backslashes that aren't escaping a unicode character code, like \\u01a2
+  // Small risk of false positives e.g. is C:\\Users\\u2bfab\\ unicode, or a U2 fan?
+  // So, catch basic multilingual (4 char) only. No hieroglyphs or ancient Mayan.
+  const startPath = line.search(/\\(?!u[0-9A-Fa-f]{4})/)
+  if (startPath === -1) return line
+
+  // Replace any \\ that's not part of a unicode escape character
+  const replaceRegex = /\\(?!u[0-9A-Fa-f]{4})/g
+  // \u005c is the unicode escape for the \ char
+  return line.slice(0, startPath) + line.slice(startPath).replace(replaceRegex, '\\u005c')
 }
 
 function v8LogToTicks (isolateLogPath, node) {
@@ -55,6 +51,7 @@ function v8LogToTicks (isolateLogPath, node) {
   const sp = isJson || spawn(node, [
     '--prof-process', '--preprocess', '-j', isolateLogPath
   ], { stdio: ['ignore', 'pipe', 'pipe'] })
+
   const close = isJson ? () => {} : () => sp.kill()
   const srcStream = isJson ? fs.createReadStream(isolateLogPath) : sp.stdout
   if (!isJson) {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "which": "^1.2.4"
   },
   "devDependencies": {
+    "esprima": "^4.0.1",
+    "rimraf": "^2.6.2",
     "snazzy": "^8.0.0",
     "standard": "^12.0.1",
     "tap": "^12.0.1"

--- a/test/fixture/do-eval.js
+++ b/test/fixture/do-eval.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const {
+  allTags,
+  regexWindowsPaths,
+  stringPosixPaths,
+  nonPathRegex
+} = require('../util/type-edge-cases.js')
+
+const {
+  evalSafeString,
+  evalSafeRegexDef
+} = require('../util/ensure-eval-safe.js')
+
+const doFunc = require('./μИاκهよΞ/unicode-in-path.js')
+
+const debounce = require('debounce')
+
+function appOuterFunc () {
+  const regexStringTarget = `${allTags} ${regexWindowsPaths} ${stringPosixPaths}`
+
+  const evalCode = `
+    function evalInnerFunc () {
+      const regex = new RegExp(${evalSafeRegexDef(`"${regexWindowsPaths}"`)})
+      return ${evalSafeString(`"${regexStringTarget}"`)}.repeat(100).replace(regex, ${evalSafeString(`"${stringPosixPaths}"`)})
+    }
+    evalInnerFunc()
+  `
+
+  // Long enough for consistent output, not so long test is slow or may time out
+  const reps = 120
+
+  const obj = {
+    // Method names defined from a variable show up as (anonymous)
+    // but crazy method names written in as strings still show up in output
+    'method: \\μИاκهよΞ\\ [CODE:RegExp] / native / [SHARED_LIB]': function () {
+      global.eval(evalCode)
+      regexStringTarget.repeat(reps).replace(new RegExp(nonPathRegex), stringPosixPaths)
+    }
+  }
+
+  const doEval = function () {
+    obj['method: \\μИاκهよΞ\\ [CODE:RegExp] / native / [SHARED_LIB]']()
+  }
+
+  for (let i = 0; i < reps; i++) {
+    doFunc(doEval)
+  }
+}
+
+// This debounce wrapper is purely to get a simple stable 'deps' frame in the output
+const debounceWrapper = debounce(appOuterFunc, 0, true)
+debounceWrapper()

--- a/test/fixture/do-eval.js
+++ b/test/fixture/do-eval.js
@@ -34,7 +34,7 @@ function appOuterFunc () {
     // Method names defined from a variable show up as (anonymous)
     // but crazy method names written in as strings still show up in output
     'method: \\μИاκهよΞ\\ [CODE:RegExp] / native / [SHARED_LIB]': function () {
-      global.eval(evalCode)
+      global.eval(evalCode) // eslint-disable-line
       regexStringTarget.repeat(reps).replace(new RegExp(nonPathRegex), stringPosixPaths)
     }
   }

--- a/test/fixture/μИاκهよΞ/unicode-in-path.js
+++ b/test/fixture/μИاκهよΞ/unicode-in-path.js
@@ -1,0 +1,10 @@
+'use strict'
+
+// This puts some non-ascii unicode characters in frame's file path
+// to simulate a user with a non-ascii username or ancestor directory
+
+function doFunc (func) {
+  func()
+}
+
+module.exports = doFunc

--- a/test/util/classify-frames.js
+++ b/test/util/classify-frames.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const render = require('nanohtml')
+const ticksToTree = require('../../lib/ticks-to-tree.js')
+const { v8cats } = require('../../visualizer/cmp/graph.js')(render)
+
+function getType (frame, inlined) {
+  const processedFrame = Object.assign({}, frame, { name: getProcessedName(frame, inlined) })
+  return getTypeProcessed(processedFrame)
+}
+
+function getTypeProcessed (frame) {
+  return v8cats(frame).type
+}
+
+function getProcessedName (frame, inlined) {
+  const { name } = frame
+
+  if (inlined) {
+    const parentName = 'evalParent :1:2'
+
+    const key = name.split(':')[0]
+    const options = {
+      inlined: {}
+    }
+    options.inlined[key] = [{
+      caller: { key: parentName.split(':')[0] }
+    }]
+
+    const tree = ticksToTree([[{ name: parentName }, frame]], options)
+    return tree.unmerged.children[0].children[0].name
+  } else {
+    const tree = ticksToTree([[frame]])
+    return tree.unmerged.children[0].name
+  }
+}
+
+module.exports = {
+  getType,
+  getProcessedName
+}

--- a/test/util/ensure-eval-safe.js
+++ b/test/util/ensure-eval-safe.js
@@ -1,0 +1,77 @@
+'use strict'
+
+const esprima = require('esprima')
+const assert = require('assert')
+
+/**
+ * Can't be too careful with eval.
+ * Check no-one slipped something malicious in the complex strings
+ **/
+
+function mainSafetyCheck (parsed, type = 'Literal') {
+  // Check there's only one expression
+  assert.strictEqual(parsed.body.length, 1)
+  // Check it's what we expected
+  assert.strictEqual(parsed.body[0].type, 'ExpressionStatement')
+  assert.strictEqual(parsed.body[0].expression.type, type)
+}
+
+function stringSafetyCheck (str, escapedRegex = false) {
+  // Check that when parsed as JS this is nothing but the original string
+  const strParsed = esprima.parse(escapeRegex(str))
+  mainSafetyCheck(strParsed)
+
+  // expression.value is a string-like object containing the string
+  let compare = '' + strParsed.body[0].expression.value
+
+  if (escapeRegex) {
+    // Make formats match:
+    // - Strip any surrounding " that may have been added to input
+    // - Ensure that in a regex, all \\ are \\\\ on both sides
+    str = escapeRegex(str.replace(/^"(.*)"$/, '$1'))
+    compare = escapeRegex(compare)
+  }
+
+  assert.equal(compare, str)
+}
+
+function regexSafetyCheck (str) {
+  // Check that when parsed as JS in new RegExp(), this is nothing but the expected regex
+
+  const regexParsed = esprima.parse(`new RegExp(${str})`)
+  mainSafetyCheck(regexParsed, 'NewExpression')
+
+  assert.strictEqual(regexParsed.body[0].expression.type, 'NewExpression')
+
+  assert.strictEqual(regexParsed.body[0].expression.callee.name, 'RegExp')
+  assert.strictEqual(regexParsed.body[0].expression.callee.type, 'Identifier')
+  assert.strictEqual(Object.keys(regexParsed.body[0].expression.callee).length, 2)
+
+  assert.strictEqual(regexParsed.body[0].expression.arguments.length, 1)
+
+  assert.strictEqual(regexParsed.body[0].expression.arguments[0].raw, str)
+
+  assert.strictEqual(Object.keys(regexParsed.body[0].expression).length, 3)
+}
+
+function evalSafeString (str) {
+  stringSafetyCheck(str)
+  return str
+}
+
+function evalSafeRegexDef (str) {
+  const escaped = escapeRegex(str)
+  stringSafetyCheck(escaped, true)
+  regexSafetyCheck(escaped)
+  return escaped
+}
+
+function escapeRegex (str) {
+  // Each \\ will be treated as an escape character by eval
+  return str.replace(/([^\\])\\([^\\])/g, '$1\\\\$2')
+}
+
+module.exports = {
+  evalSafeString,
+  evalSafeRegexDef
+}

--- a/test/util/ensure-eval-safe.js
+++ b/test/util/ensure-eval-safe.js
@@ -32,7 +32,7 @@ function stringSafetyCheck (str, escapedRegex = false) {
     compare = escapeRegex(compare)
   }
 
-  assert.equal(compare, str)
+  assert.strictEqual(compare, str)
 }
 
 function regexSafetyCheck (str) {

--- a/test/util/type-edge-cases.js
+++ b/test/util/type-edge-cases.js
@@ -1,0 +1,60 @@
+'use strict'
+
+const { unescape } = require('querystring')
+
+/**
+ * Difficult examples containing various possible edge cases, to:
+ *  - Avoid false positives in type detection
+ *  - Ensure that nothing chokes on non-ASCII characters
+ *  - Ensure that less common but valid path types are handled correctly
+ **/
+
+const regexpTag = '[CODE:RegExp]'
+const evalTag = '[eval]'
+const nativeTag = ' native '
+const initTag = '[INIT]'
+const inlinableTag = '[INLINABLE]'
+const v8CodeTag = '[CODE:someString]'
+const cppTag = '[CPP]'
+const allTags = `${regexpTag} ${evalTag} ${nativeTag} ${initTag} ${inlinableTag} ${v8CodeTag} ${cppTag}`
+
+// Includes spaces, Chinese characters, [CODE:RegExp] in folder name, and .mjs folder name in a non-js-file path
+// : is forbidden in filenames in Windows, Mac and _most_ Linux distros - but can't guarentee all
+const sharedLibUnix = '/home/中文.mjs project/[CODE:RegExp] [CODE:RegExp] [CODE:RegExp]lib/node'
+
+// Windows path not starting with drive letter, containing ' native ', [eval] and .js at the end of a folder name in a non-js-file path
+const sharedLibWindows = '\\\\remote.smb.js.server.net\\the native dev\\[eval] [eval] [eval]\\node.js\\lib\\node'
+
+// Windows path not on drive C, including spaces, 'internal\\', ' native ', Cyrillic, Xhosa, and an ESM module
+const depsEsmWindows = 'D:\\Documents and Settings\\Александра ǂǐ-sì\\internal\\app native internal\\node_modules\\some-module\\esm.mjs:1:1'
+
+// Includes spaces, non-ASCII european characters, joining diacritics, a single quote, ' internal/', ' native ', and
+// 'node conf dubai' in Arabic, right-to-left, with joins. Encoded because some editors (e.g. Sublime) garble rtl text
+const nodeConfDubai = unescape('%D9%86%D9%88%D8%AF%20%D9%83%D9%88%D9%86%D9%81%20%D8%AF%D8%A8%D9%8A')
+const depsCommonUnix = `/home/Łukasz W̥̙̯. O'Reilly/projects/${nodeConfDubai}/internal/app native internal/node_modules/module/common.js:111:111`
+
+// Includes 'node_modules\\', but isn't a dep
+const appWindows = '\\\\my_unc_server\\my_unc_shares\\my_projects\\my_node_modules\\my_module\\index.js:1234567890:1234567890'
+
+// Includes '/node_modules', but isn't a dep
+const appUnix = '//unc_server/unc_share-bob/current_projects-bob/node_modules-bob/bobule/index.js:1234567890:1234567890'
+
+// Use Windows paths in the regex because Unix path seperators (/) would be escaped in a regex
+const regexWindowsPaths = '/' + depsEsmWindows + ' ' + sharedLibWindows + ' ' + appWindows + ' ' + allTags + '/g'
+const stringPosixPaths = `${depsCommonUnix} ${sharedLibUnix} ${appUnix} ${allTags}`
+
+// Contains \\ outside of complete paths, a :\\ with \\ both before and after it, and \\u.... patterns which aren't unicode character codes
+const nonPathRegex = '/[\/\\] \.js native \.mjs \\ \/ :\\ \/ \\ \\\\server (\\users\\u2fan\\node_modules\\|\/node_modules\/) \[eval].js:1:2/'
+
+module.exports = {
+  allTags,
+  regexWindowsPaths,
+  stringPosixPaths,
+  nonPathRegex,
+  sharedLibUnix,
+  sharedLibWindows,
+  depsEsmWindows,
+  depsCommonUnix,
+  appUnix,
+  appWindows
+}

--- a/test/util/type-edge-cases.js
+++ b/test/util/type-edge-cases.js
@@ -44,7 +44,7 @@ const regexWindowsPaths = '/' + depsEsmWindows + ' ' + sharedLibWindows + ' ' + 
 const stringPosixPaths = `${depsCommonUnix} ${sharedLibUnix} ${appUnix} ${allTags}`
 
 // Contains \\ outside of complete paths, a :\\ with \\ both before and after it, and \\u.... patterns which aren't unicode character codes
-const nonPathRegex = '/[\/\\] \.js native \.mjs \\ \/ :\\ \/ \\ \\\\server (\\users\\u2fan\\node_modules\\|\/node_modules\/) \[eval].js:1:2/'
+const nonPathRegex = '/[\/\\] \.js native \.mjs \\ \/ :\\ \/ \\ \\\\server (\\users\\u2fan\\node_modules\\|\/node_modules\/) \[eval].js:1:2/' // eslint-disable-line
 
 module.exports = {
   allTags,

--- a/test/util/type-simple-cases.js
+++ b/test/util/type-simple-cases.js
@@ -1,0 +1,45 @@
+'use strict'
+
+/**
+ * Simple examples of typical cases
+ * These are all adapted from real profiles generated from demo applications
+ **/
+
+const init1 = { name: 'NativeModule.compile internal/bootstrap/loaders.js:236:44', type: 'JS' }
+const init2 = { name: 'bootstrapNodeJSCore internal/bootstrap/node.js:12:24', type: 'JS' }
+const cpp1 = { name: '/usr/bin/node', type: 'SHARED_LIB' }
+const cpp2 =  { name: 'C:\\Program Files\\nodejs\\node.exe', type: 'SHARED_LIB' }
+const v81 = { name: 'v8::internal::Runtime_CompileLazy(int, v8::internal::Object**, v8::internal::Isolate*)', type: 'CPP' }
+const v82 = { name: 'Call_ReceiverIsNotNullOrUndefined', type: 'CODE', kind: 'BuiltIn' }
+const regexp1 = { name: '[\u0000zA-Z\u0000#$%&\'*+.|~]+$', type: 'CODE', kind: 'RegExp' }
+const regexp2 = { name: '; *([!#$%&\'*+.^_`|~0-9A-Za-z-]+) *= *("(?:[ !#-[]-~-ÿ]|00b -ÿ])*"|[!#$%&\'*+.^_`|~0-9A-Za-z-]+) *', type: 'CODE', kind: 'RegExp' }
+const native1 = { name: 'InnerArraySort native array.js:486:24', type: 'JS', kind: 'Unopt' }
+const native2 = { name: '(anonymous) :486:24', type: 'JS', kind: 'Opt' }
+const core1 = { name: 'validatePath internal/fs/utils.js:442:22', type: 'JS', kind: 'Opt' }
+const core2 = { name: 'nullCheck internal/fs/utils.js:188:19', type: 'JS', kind: 'Unopt' }
+const deps1 = { name: 'run /root/0x/examples/rest-api/node_modules/restify/lib/server.js:807:38', type: 'JS', kind: 'Opt' }
+const deps2 = { name: 'next C:\\Users\\Name With Spaces\\Documents\\app\\node_modules\\express\\lib\\router\\index.js:176:16', type: 'JS', kind: 'Unopt' }
+const app1 = { name: '(anonymous) /root/0x/examples/rest-api/etag.js:1:11', type: 'JS', kind: 'Unopt' }
+const app2 = { name: 'app.get C:\\Documents And Settings\\node-clinic-flame-demo\\1-server-with-slow-function.js:8:14', type: 'JS', kind: 'Opt' }
+const inlinable = { name: 'getMediaTypePriority /root/0x/examples/rest-api/node_modules/negotiator/lib/mediaType.js:99:30', type: 'JS', kind: 'Unopt' }
+
+// Make it iterable with keys so tests can loop through and get expected results by key
+module.exports = {
+  init1,
+  init2,
+  cpp1,
+  cpp2,
+  v81,
+  v82,
+  regexp1,
+  regexp2,
+  native1,
+  native2,
+  core1,
+  core2,
+  deps1,
+  deps2,
+  app1,
+  app2,
+  inlinable
+}

--- a/test/util/type-simple-cases.js
+++ b/test/util/type-simple-cases.js
@@ -8,7 +8,7 @@
 const init1 = { name: 'NativeModule.compile internal/bootstrap/loaders.js:236:44', type: 'JS' }
 const init2 = { name: 'bootstrapNodeJSCore internal/bootstrap/node.js:12:24', type: 'JS' }
 const cpp1 = { name: '/usr/bin/node', type: 'SHARED_LIB' }
-const cpp2 =  { name: 'C:\\Program Files\\nodejs\\node.exe', type: 'SHARED_LIB' }
+const cpp2 = { name: 'C:\\Program Files\\nodejs\\node.exe', type: 'SHARED_LIB' }
 const v81 = { name: 'v8::internal::Runtime_CompileLazy(int, v8::internal::Object**, v8::internal::Isolate*)', type: 'CPP' }
 const v82 = { name: 'Call_ReceiverIsNotNullOrUndefined', type: 'CODE', kind: 'BuiltIn' }
 const regexp1 = { name: '[\u0000zA-Z\u0000#$%&\'*+.|~]+$', type: 'CODE', kind: 'RegExp' }

--- a/test/v8-names-static.test.js
+++ b/test/v8-names-static.test.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const { test } = require('tap')
+
+const {
+  init1,
+  init2,
+  cpp1,
+  cpp2,
+  v81,
+  v82,
+  regexp1,
+  regexp2,
+  native1,
+  native2,
+  core1,
+  core2,
+  deps1,
+  deps2,
+  app1,
+  app2,
+  inlinable
+} = require('./util/type-simple-cases.js')
+
+const { getProcessedName } = require('./util/classify-frames.js')
+
+test('Test typical examples - backend name transformation', function (t) {
+  t.equal(getProcessedName(init1), init1.name + ' [INIT]')
+  t.equal(getProcessedName(init2), init2.name + ' [INIT]')
+  t.equal(getProcessedName(cpp1), cpp1.name + ' [SHARED_LIB]')
+  t.equal(getProcessedName(cpp2), cpp2.name + ' [SHARED_LIB]')
+  t.equal(getProcessedName(v81), v81.name + ' [CPP]')
+  t.equal(getProcessedName(v82), v82.name + ' [CODE:BuiltIn]')
+  t.equal(getProcessedName(regexp1), regexp1.name + ' [CODE:RegExp]')
+  t.equal(getProcessedName(regexp2), regexp2.name + ' [CODE:RegExp]')
+  t.equal(getProcessedName(native1), '~' + native1.name)
+  t.equal(getProcessedName(native2), '*(anonymous) [eval]:486:24')
+  t.equal(getProcessedName(core1), '*' + core1.name)
+  t.equal(getProcessedName(core2), '~' + core2.name)
+  t.equal(getProcessedName(deps1), '*' + deps1.name)
+  t.equal(getProcessedName(deps2), '~' + deps2.name)
+  t.equal(getProcessedName(app1), '~' + app1.name)
+  t.equal(getProcessedName(app2), '*' + app2.name)
+  t.equal(getProcessedName(inlinable, true), '~' + inlinable.name + ' [INLINABLE]')
+
+  t.end()
+})

--- a/test/v8-types-generated.test.js
+++ b/test/v8-types-generated.test.js
@@ -86,94 +86,78 @@ test('Ensure eval sanitising works as expected before using fixture', function (
   t.end()
 })
 
-test('Generate profile and test its output', function (outerTest) {
-  outerTest.plan(3)
-
+test('Generate profile and test its output', async function (t) {
   const readFile = promisify(fs.readFile)
   let dir
-
-  zeroX({
-    argv: [ resolve(__dirname, './fixture/do-eval.js') ],
-    workingDir: resolve('./')
-  }).catch(onError)
-    .then(testZeroXOutput, onError)
-    .then(readFile, onError)
-    .then(testJsonContents, onError)
-    .then(cleanup, onError)
-    .then(outerTest.end, onError)
-
-  function onError (err) {
+  const cleanup = function () {
+    if (dir) {
+      t.ok(fs.existsSync(dir))
+      rimraf.sync(dir)
+      t.notOk(fs.existsSync(dir))
+    }
+    t.end()
+  }
+  const onError = function (err) {
     cleanup()
     throw err
   }
 
-  function testZeroXOutput (htmlLink) {
-    const htmlFile = htmlLink.replace(/^file:\/\//, '')
+  const htmlLink = await zeroX({
+    argv: [ resolve(__dirname, './fixture/do-eval.js') ],
+    workingDir: resolve('./')
+  }).catch(onError)
 
-    outerTest.test('Test 0x output exists as expected', function (t) {
-      t.ok(htmlFile.includes('flamegraph.html'))
-      t.ok(fs.existsSync(htmlFile))
-      t.ok(fs.statSync(htmlFile).size > 10000)
-      t.end()
-    })
+  const htmlFile = htmlLink.replace(/^file:\/\//, '')
 
-    dir = htmlFile.replace('flamegraph.html', '')
-    const jsonFile = fs.readdirSync(dir).find(name => name.match(/\.json$/))
-    return path.resolve(dir, jsonFile)
-  }
+  // Test 0x output exists as expected
+  t.ok(htmlFile.includes('flamegraph.html'))
+  t.ok(fs.existsSync(htmlFile))
+  t.ok(fs.statSync(htmlFile).size > 10000)
 
-  function testJsonContents (content) {
-    const jsonArray = JSON.parse(content).code
+  dir = htmlFile.replace('flamegraph.html', '')
+  const jsonFile = fs.readdirSync(dir).find(name => name.match(/\.json$/))
 
-    const app = jsonArray.find(item => item.name.match(/^appOuterFunc /))
-    const appUnicode = jsonArray.find(item => item.name.match(/^doFunc.+μИاκهよΞ[/\\]unicode-in-path\.js/))
-    const appLongMethod = jsonArray.find(item => item.type === 'JS' && item.name.match(/^method: \\μИاκهよΞ\\ \[CODE:RegExp] \/ native \/ \[SHARED_LIB]/))
+  const content = await readFile(path.resolve(dir, jsonFile)).catch(onError)
 
-    const deps = jsonArray.find(item => item.name.match(/node_modules[/\\]debounce/))
+  const jsonArray = JSON.parse(content).code
 
-    // We get into multi-level escape character hell if we try to escape then match against the original strings
-    // Duplicate stubs long enough to check it's a) correctly classified, and b) unicode etc isn't mangled
-    const matchRegexPaths = /^\/D:\u005cDocuments and Settings\u005cАлександра ǂǐ-sì\u005cinternal\u005capp native internal\u005cnode_modules\u005csome-module\u005cesm.mjs:1:1/
-    const regexPaths = jsonArray.find(item => item.name.match(matchRegexPaths))
-    const matchRegexNonPath = /^\/\[\/\u005c] \.js native \.mjs \u005c \/ :\u005c \/ \u005c \u005c\u005cserver \(\u005cusers\u005cu2fan\u005cnode_modules\u005c\|\/node_modules\/\) \[eval].js:1:2/
-    const regexNonPath = jsonArray.find(item => item.name.match(matchRegexNonPath))
+  const app = jsonArray.find(item => item.name.match(/^appOuterFunc /))
+  const appUnicode = jsonArray.find(item => item.name.match(/^doFunc.+μИاκهよΞ[/\\]unicode-in-path\.js/))
+  const appLongMethod = jsonArray.find(item => item.type === 'JS' && item.name.match(/^method: \\μИاκهよΞ\\ \[CODE:RegExp] \/ native \/ \[SHARED_LIB]/))
 
-    const evalFunc = jsonArray.find(item => item.type === 'JS' && item.name.match(/^evalInnerFunc /))
+  const deps = jsonArray.find(item => item.name.match(/node_modules[/\\]debounce/))
 
-    outerTest.test('Test 0x json contents are logged and classified as expected', function (t) {
-      t.ok(app)
-      t.equal(getType(app), 'app')
+  // We get into multi-level escape character hell if we try to escape then match against the original strings
+  // Duplicate stubs long enough to check it's a) correctly classified, and b) unicode etc isn't mangled
+  const matchRegexPaths = /^\/D:\u005cDocuments and Settings\u005cАлександра ǂǐ-sì\u005cinternal\u005capp native internal\u005cnode_modules\u005csome-module\u005cesm.mjs:1:1/
+  const regexPaths = jsonArray.find(item => item.name.match(matchRegexPaths))
+  const matchRegexNonPath = /^\/\[\/\u005c] \.js native \.mjs \u005c \/ :\u005c \/ \u005c \u005c\u005cserver \(\u005cusers\u005cu2fan\u005cnode_modules\u005c\|\/node_modules\/\) \[eval].js:1:2/
+  const regexNonPath = jsonArray.find(item => item.name.match(matchRegexNonPath))
 
-      t.ok(appUnicode)
-      t.equal(getType(appUnicode), 'app')
+  const evalFunc = jsonArray.find(item => item.type === 'JS' && item.name.match(/^evalInnerFunc /))
 
-      t.ok(appLongMethod)
-      t.equal(getType(appLongMethod), 'app')
+  // Test 0x json contents are logged and classified as expected
+  t.ok(app)
+  t.equal(getType(app), 'app')
 
-      t.ok(deps)
-      t.equal(getType(deps), 'deps')
+  t.ok(appUnicode)
+  t.equal(getType(appUnicode), 'app')
 
-      t.ok(regexPaths)
-      t.equal(getType(regexPaths), 'regexp')
+  t.ok(appLongMethod)
+  t.equal(getType(appLongMethod), 'app')
 
-      t.ok(regexNonPath)
-      t.equal(getType(regexNonPath), 'regexp')
+  t.ok(deps)
+  t.equal(getType(deps), 'deps')
 
-      t.ok(evalFunc)
-      t.equal(getType(evalFunc), 'native')
-      t.ok(getProcessedName(evalFunc).includes('[eval]'))
+  t.ok(regexPaths)
+  t.equal(getType(regexPaths), 'regexp')
 
-      t.end()
-    })
-  }
+  t.ok(regexNonPath)
+  t.equal(getType(regexNonPath), 'regexp')
 
-  function cleanup () {
-    outerTest.test('Test cleanup works as expected', function (t) {
-      t.ok(fs.existsSync(dir))
-      rimraf.sync(dir)
-      t.notOk(fs.existsSync(dir))
+  t.ok(evalFunc)
+  t.equal(getType(evalFunc), 'native')
+  t.ok(getProcessedName(evalFunc).includes('[eval]'))
 
-      t.end()
-    })
-  }
+  cleanup()
 })

--- a/test/v8-types-generated.test.js
+++ b/test/v8-types-generated.test.js
@@ -34,35 +34,34 @@ test('Ensure eval sanitising works as expected before using fixture', function (
   }, { actual: 'BinaryExpression', expected: 'Literal' })
 
   t.throws(function () {
-    evalSafeString("`some string${ console.log('>>> Do bad things') }`")
+    evalSafeString("`some string${ console.log('>>> Do bad things') }`") // eslint-disable-line
   }, { actual: 'TemplateLiteral', expected: 'Literal' })
 
   // Simulate redefining 'RegExp' to be malicious when it is called later by an innocent 'new RegExp()'
   t.throws(function () {
     evalSafeString("function RegExp () { console.log('>>> Do bad things') }")
-  }, { actual: 'FunctionDeclaration' , expected: 'ExpressionStatement' })
+  }, { actual: 'FunctionDeclaration', expected: 'ExpressionStatement' })
 
   t.throws(function () {
     evalSafeString("RegExp = function () { console.log('>>> Do bad things') }")
-  }, { actual: 'AssignmentExpression' , expected: 'Literal' })
+  }, { actual: 'AssignmentExpression', expected: 'Literal' })
 
   t.throws(function () {
-    evalSafeString("`some string${ function RegExp () { console.log('>>> Do bad things') } }`")
-  }, { actual: 'TemplateLiteral' , expected: 'Literal' })
+    evalSafeString("`some string${ function RegExp () { console.log('>>> Do bad things') } }`") // eslint-disable-line
+  }, { actual: 'TemplateLiteral', expected: 'Literal' })
 
   t.throws(function () {
     evalSafeString("'/abc/' && (RegExp = function () { console.log('>>> Do bad things') })")
-  }, { actual: 'LogicalExpression' , expected: 'Literal' })
+  }, { actual: 'LogicalExpression', expected: 'Literal' })
 
   t.throws(function () {
     evalSafeString("(RegExp = function () { console.log('>>> Do bad things') }) && '/abc/'")
-    global.eval(str + "; new RegExp('/abc/');")
-  }, { actual: 'LogicalExpression' , expected: 'Literal' })
+  }, { actual: 'LogicalExpression', expected: 'Literal' })
 
   // Test regex creation
   t.throws(function () {
     evalSafeRegexDef("'/abc'; console.log('>>> Do bad things');")
-  }, { actual: 2 , expected: 1 })
+  }, { actual: 2, expected: 1 })
 
   t.throws(function () {
     evalSafeRegexDef("'/abc' + console.log('>>> Do bad things')")
@@ -70,19 +69,19 @@ test('Ensure eval sanitising works as expected before using fixture', function (
 
   t.throws(function () {
     evalSafeRegexDef("(RegExp = function () { console.log('>>> Do bad things') }) && '/abc/'")
-  }, { actual: 'LogicalExpression' , expected: 'Literal' })
+  }, { actual: 'LogicalExpression', expected: 'Literal' })
 
   t.throws(function () {
     evalSafeRegexDef("'/abc/' && (RegExp = function () { console.log('>>> Do bad things') })")
-  }, { actual: 'LogicalExpression' , expected: 'Literal' })
+  }, { actual: 'LogicalExpression', expected: 'Literal' })
 
   t.throws(function () {
-    evalSafeRegexDef("`/abc${ console.log('>>> Do bad things') }/`")
-  }, { actual: 'TemplateLiteral' , expected: 'Literal' })
+    evalSafeRegexDef("`/abc${ console.log('>>> Do bad things') }/`") // eslint-disable-line
+  }, { actual: 'TemplateLiteral', expected: 'Literal' })
 
   t.throws(function () {
-    evalSafeRegexDef("`/abc${ function RegExp () { console.log('>>> Do bad things') } }/`")
-  }, { actual: 'TemplateLiteral' , expected: 'Literal' })
+    evalSafeRegexDef("`/abc${ function RegExp () { console.log('>>> Do bad things') } }/`") // eslint-disable-line
+  }, { actual: 'TemplateLiteral', expected: 'Literal' })
 
   t.end()
 })

--- a/test/v8-types-generated.test.js
+++ b/test/v8-types-generated.test.js
@@ -1,0 +1,180 @@
+'use strict'
+
+const { test } = require('tap')
+
+const { resolve } = require('path')
+const fs = require('fs')
+const path = require('path')
+const { promisify } = require('util')
+const rimraf = require('rimraf')
+const zeroX = require('../')
+
+const {
+  getProcessedName,
+  getType
+} = require('./util/classify-frames.js')
+
+const {
+  evalSafeRegexDef,
+  evalSafeString
+} = require('./util/ensure-eval-safe.js')
+
+// Be careful if increasing this test file's run time (currently ~5-12s).
+// Tap may intermittently fail with "no plan" or, if plans are added,
+// mistaken "incorrect number of tests" errors if run time is > ~25s.
+
+// We only have input from our own module, but still, the strings are complex, check they can't contain surprises
+test('Ensure eval sanitising works as expected before using fixture', function (t) {
+  t.throws(function () {
+    evalSafeString("'some string'; console.log('>>> Do bad things');")
+  }, { actual: 2, expected: 1 })
+
+  t.throws(function () {
+    evalSafeString("'some string' + console.log('>>> Do bad things');")
+  }, { actual: 'BinaryExpression', expected: 'Literal' })
+
+  t.throws(function () {
+    evalSafeString("`some string${ console.log('>>> Do bad things') }`")
+  }, { actual: 'TemplateLiteral', expected: 'Literal' })
+
+  // Simulate redefining 'RegExp' to be malicious when it is called later by an innocent 'new RegExp()'
+  t.throws(function () {
+    evalSafeString("function RegExp () { console.log('>>> Do bad things') }")
+  }, { actual: 'FunctionDeclaration' , expected: 'ExpressionStatement' })
+
+  t.throws(function () {
+    evalSafeString("RegExp = function () { console.log('>>> Do bad things') }")
+  }, { actual: 'AssignmentExpression' , expected: 'Literal' })
+
+  t.throws(function () {
+    evalSafeString("`some string${ function RegExp () { console.log('>>> Do bad things') } }`")
+  }, { actual: 'TemplateLiteral' , expected: 'Literal' })
+
+  t.throws(function () {
+    evalSafeString("'/abc/' && (RegExp = function () { console.log('>>> Do bad things') })")
+  }, { actual: 'LogicalExpression' , expected: 'Literal' })
+
+  t.throws(function () {
+    evalSafeString("(RegExp = function () { console.log('>>> Do bad things') }) && '/abc/'")
+    global.eval(str + "; new RegExp('/abc/');")
+  }, { actual: 'LogicalExpression' , expected: 'Literal' })
+
+  // Test regex creation
+  t.throws(function () {
+    evalSafeRegexDef("'/abc'; console.log('>>> Do bad things');")
+  }, { actual: 2 , expected: 1 })
+
+  t.throws(function () {
+    evalSafeRegexDef("'/abc' + console.log('>>> Do bad things')")
+  }, { actual: 'BinaryExpression', expected: 'Literal' })
+
+  t.throws(function () {
+    evalSafeRegexDef("(RegExp = function () { console.log('>>> Do bad things') }) && '/abc/'")
+  }, { actual: 'LogicalExpression' , expected: 'Literal' })
+
+  t.throws(function () {
+    evalSafeRegexDef("'/abc/' && (RegExp = function () { console.log('>>> Do bad things') })")
+  }, { actual: 'LogicalExpression' , expected: 'Literal' })
+
+  t.throws(function () {
+    evalSafeRegexDef("`/abc${ console.log('>>> Do bad things') }/`")
+  }, { actual: 'TemplateLiteral' , expected: 'Literal' })
+
+  t.throws(function () {
+    evalSafeRegexDef("`/abc${ function RegExp () { console.log('>>> Do bad things') } }/`")
+  }, { actual: 'TemplateLiteral' , expected: 'Literal' })
+
+  t.end()
+})
+
+test('Generate profile and test its output', function (outerTest) {
+  outerTest.plan(3)
+
+  const readFile = promisify(fs.readFile)
+  let dir
+
+  zeroX({
+    argv: [ resolve(__dirname, './fixture/do-eval.js') ],
+    workingDir: resolve('./')
+  }).catch(onError)
+    .then(testZeroXOutput, onError)
+    .then(readFile, onError)
+    .then(testJsonContents, onError)
+    .then(cleanup, onError)
+    .then(outerTest.end, onError)
+
+  function onError (err) {
+    cleanup()
+    throw err
+  }
+
+  function testZeroXOutput (htmlLink) {
+    const htmlFile = htmlLink.replace(/^file:\/\//, '')
+
+    outerTest.test('Test 0x output exists as expected', function (t) {
+      t.ok(htmlFile.includes('flamegraph.html'))
+      t.ok(fs.existsSync(htmlFile))
+      t.ok(fs.statSync(htmlFile).size > 10000)
+      t.end()
+    })
+
+    dir = htmlFile.replace('flamegraph.html', '')
+    const jsonFile = fs.readdirSync(dir).find(name => name.match(/\.json$/))
+    return path.resolve(dir, jsonFile)
+  }
+
+  function testJsonContents (content) {
+    const jsonArray = JSON.parse(content).code
+
+    const app = jsonArray.find(item => item.name.match(/^appOuterFunc /))
+    const appUnicode = jsonArray.find(item => item.name.match(/^doFunc.+μИاκهよΞ[/\\]unicode-in-path\.js/))
+    const appLongMethod = jsonArray.find(item => item.type === 'JS' && item.name.match(/^method: \\μИاκهよΞ\\ \[CODE:RegExp] \/ native \/ \[SHARED_LIB]/))
+
+    const deps = jsonArray.find(item => item.name.match(/node_modules[/\\]debounce/))
+
+    // We get into multi-level escape character hell if we try to escape then match against the original strings
+    // Duplicate stubs long enough to check it's a) correctly classified, and b) unicode etc isn't mangled
+    const matchRegexPaths = /^\/D:\u005cDocuments and Settings\u005cАлександра ǂǐ-sì\u005cinternal\u005capp native internal\u005cnode_modules\u005csome-module\u005cesm.mjs:1:1/
+    const regexPaths = jsonArray.find(item => item.name.match(matchRegexPaths))
+    const matchRegexNonPath = /^\/\[\/\u005c] \.js native \.mjs \u005c \/ :\u005c \/ \u005c \u005c\u005cserver \(\u005cusers\u005cu2fan\u005cnode_modules\u005c\|\/node_modules\/\) \[eval].js:1:2/
+    const regexNonPath = jsonArray.find(item => item.name.match(matchRegexNonPath))
+
+    const evalFunc = jsonArray.find(item => item.type === 'JS' && item.name.match(/^evalInnerFunc /))
+
+    outerTest.test('Test 0x json contents are logged and classified as expected', function (t) {
+      t.ok(app)
+      t.equal(getType(app), 'app')
+
+      t.ok(appUnicode)
+      t.equal(getType(appUnicode), 'app')
+
+      t.ok(appLongMethod)
+      t.equal(getType(appLongMethod), 'app')
+
+      t.ok(deps)
+      t.equal(getType(deps), 'deps')
+
+      t.ok(regexPaths)
+      t.equal(getType(regexPaths), 'regexp')
+
+      t.ok(regexNonPath)
+      t.equal(getType(regexNonPath), 'regexp')
+
+      t.ok(evalFunc)
+      t.equal(getType(evalFunc), 'native')
+      t.ok(getProcessedName(evalFunc).includes('[eval]'))
+
+      t.end()
+    })
+  }
+
+  function cleanup () {
+    outerTest.test('Test cleanup works as expected', function (t) {
+      t.ok(fs.existsSync(dir))
+      rimraf.sync(dir)
+      t.notOk(fs.existsSync(dir))
+
+      t.end()
+    })
+  }
+})

--- a/test/v8-types-static.test.js
+++ b/test/v8-types-static.test.js
@@ -1,0 +1,94 @@
+'use strict'
+
+const { test } = require('tap')
+
+const {
+  init1,
+  init2,
+  cpp1,
+  cpp2,
+  v81,
+  v82,
+  regexp1,
+  regexp2,
+  native1,
+  native2,
+  core1,
+  core2,
+  deps1,
+  deps2,
+  app1,
+  app2,
+  inlinable
+} = require('./util/type-simple-cases.js')
+
+const {
+  regexWindowsPaths,
+  sharedLibUnix,
+  sharedLibWindows,
+  depsEsmWindows,
+  depsCommonUnix,
+  appUnix,
+  appWindows
+} = require('./util/type-edge-cases.js')
+
+const {
+  getProcessedName,
+  getType
+} = require('./util/classify-frames.js')
+
+test('Test typical examples - backend name transformation', function (t) {
+  t.equal(getProcessedName(init1), init1.name + ' [INIT]')
+  t.equal(getProcessedName(init2), init2.name + ' [INIT]')
+  t.equal(getProcessedName(cpp1), cpp1.name + ' [SHARED_LIB]')
+  t.equal(getProcessedName(cpp2), cpp2.name + ' [SHARED_LIB]')
+  t.equal(getProcessedName(v81), v81.name + ' [CPP]')
+  t.equal(getProcessedName(v82), v82.name + ' [CODE:BuiltIn]')
+  t.equal(getProcessedName(regexp1), regexp1.name + ' [CODE:RegExp]')
+  t.equal(getProcessedName(regexp2), regexp2.name + ' [CODE:RegExp]')
+  t.equal(getProcessedName(native1), '~' + native1.name)
+  t.equal(getProcessedName(native2), '*(anonymous) [eval]:486:24')
+  t.equal(getProcessedName(core1), '*' + core1.name)
+  t.equal(getProcessedName(core2), '~' + core2.name)
+  t.equal(getProcessedName(deps1), '*' + deps1.name)
+  t.equal(getProcessedName(deps2), '~' + deps2.name)
+  t.equal(getProcessedName(app1), '~' + app1.name)
+  t.equal(getProcessedName(app2), '*' + app2.name)
+  t.equal(getProcessedName(inlinable, true), '~' + inlinable.name + ' [INLINABLE]')
+
+  t.end()
+})
+
+test('Test typical examples - frontend name parsing', function (t) {
+  t.equal(getType(init1), 'init')
+  t.equal(getType(init2), 'init')
+  t.equal(getType(cpp1), 'cpp')
+  t.equal(getType(cpp2), 'cpp')
+  t.equal(getType(v81), 'v8')
+  t.equal(getType(v82), 'v8')
+  t.equal(getType(regexp1), 'regexp')
+  t.equal(getType(regexp2), 'regexp')
+  t.equal(getType(native1), 'native')
+  t.equal(getType(native2), 'native')
+  t.equal(getType(core1), 'core')
+  t.equal(getType(core2), 'core')
+  t.equal(getType(deps1), 'deps')
+  t.equal(getType(deps2), 'deps')
+  t.equal(getType(app1), 'app')
+  t.equal(getType(app2), 'app')
+  t.equal(getType(inlinable, true), 'inlinable')
+
+  t.end()
+})
+
+test('Test awkward edge cases', function (t) {
+  t.equal(getType({ name: appUnix, type: 'JS' }), 'app')
+  t.equal(getType({ name: appWindows, type: 'JS' }), 'app')
+  t.equal(getType({ name: depsEsmWindows, type: 'JS' }), 'deps')
+  t.equal(getType({ name: depsCommonUnix, type: 'JS' }), 'deps')
+  t.equal(getType({ name: sharedLibUnix, type: 'SHARED_LIB' }), 'cpp')
+  t.equal(getType({ name: sharedLibWindows, type: 'SHARED_LIB' }), 'cpp')
+  t.equal(getType({ name: regexWindowsPaths, type: 'CODE', kind: 'RegExp' }), 'regexp')
+
+  t.end()
+})

--- a/test/v8-types-static.test.js
+++ b/test/v8-types-static.test.js
@@ -32,34 +32,9 @@ const {
   appWindows
 } = require('./util/type-edge-cases.js')
 
-const {
-  getProcessedName,
-  getType
-} = require('./util/classify-frames.js')
+const { getType } = require('./util/classify-frames.js')
 
-test('Test typical examples - backend name transformation', function (t) {
-  t.equal(getProcessedName(init1), init1.name + ' [INIT]')
-  t.equal(getProcessedName(init2), init2.name + ' [INIT]')
-  t.equal(getProcessedName(cpp1), cpp1.name + ' [SHARED_LIB]')
-  t.equal(getProcessedName(cpp2), cpp2.name + ' [SHARED_LIB]')
-  t.equal(getProcessedName(v81), v81.name + ' [CPP]')
-  t.equal(getProcessedName(v82), v82.name + ' [CODE:BuiltIn]')
-  t.equal(getProcessedName(regexp1), regexp1.name + ' [CODE:RegExp]')
-  t.equal(getProcessedName(regexp2), regexp2.name + ' [CODE:RegExp]')
-  t.equal(getProcessedName(native1), '~' + native1.name)
-  t.equal(getProcessedName(native2), '*(anonymous) [eval]:486:24')
-  t.equal(getProcessedName(core1), '*' + core1.name)
-  t.equal(getProcessedName(core2), '~' + core2.name)
-  t.equal(getProcessedName(deps1), '*' + deps1.name)
-  t.equal(getProcessedName(deps2), '~' + deps2.name)
-  t.equal(getProcessedName(app1), '~' + app1.name)
-  t.equal(getProcessedName(app2), '*' + app2.name)
-  t.equal(getProcessedName(inlinable, true), '~' + inlinable.name + ' [INLINABLE]')
-
-  t.end()
-})
-
-test('Test typical examples - frontend name parsing', function (t) {
+test('Test typical examples - frontend types from names', function (t) {
   t.equal(getType(init1), 'init')
   t.equal(getType(init2), 'init')
   t.equal(getType(cpp1), 'cpp')

--- a/visualizer/cmp/graph.js
+++ b/visualizer/cmp/graph.js
@@ -8,28 +8,46 @@ module.exports = (render) => Object.assign(() => render`
   </chart>
 `, { v8cats })
 
+function includesPathSeperator (name) {
+  if (name.indexOf('/') !== -1) return true
+  return includesWindowsSeperator(name)
+}
+
+function includesWindowsSeperator (name) {
+  return (name.indexOf('\\') !== -1)
+}
+
+function isInternalPath (name) {
+  // Match like `~someFunction internal/bootstrap/node.js:1:2`
+  // not like `~someFunction /some internal/path to/file.js:1:2`, windows or posix
+  return /^[^/\\]* internal[/\\]/.test(name)
+}
+
 function v8cats (child) {
   var name = child.name
 
+  // RegExp and Eval can contain anything (a method name defined in eval could be any string)
+  if (/\[CODE:RegExp]$/.test(name)) return { type: 'regexp' }
+  // Unless we create an eval checkbox, "native" is the next best label - cannot tell if the eval is from app, deps, core
+  if (/\[eval]:\d+:\d+$/.test(name)) return { type: 'native' }
+
   if (/\[INIT]$/.test(name)) return { type: 'init' }
-
   if (/\[INLINABLE]$/.test(name)) return { type: 'inlinable' }
+  if (/\[CODE:[^\]]*]$/.test(name) || /v8::internal::.*\[CPP]$/.test(name)) return { type: 'v8' }
+  if (/\[CPP]$/.test(name) || /\[SHARED_LIB]$/.test(name)) return { type: 'cpp' }
 
-  if (!/\.m?js/.test(name)) {
-    if (/\[CODE:RegExp]$/.test(name)) return { type: 'regexp' }
-    if (/\[CODE:.*?]$/.test(name) || /v8::internal::.*\[CPP]$/.test(name)) return { type: 'v8' }
-    if (/\.$/.test(name)) return { type: 'core' }
-    if (/\[CPP]$/.test(name) || /\[SHARED_LIB]$/.test(name)) return { type: 'cpp' }
-    if (/\[eval]/.test(name)) return { type: 'native' } // unless we create an eval checkbox
-    // "native" is the next best label since
-    // you cannot tell where the eval comes
-    // from (app, deps, core)
-    return { type: 'v8' }
+  // Match like `~someFunction /some/path to/file.js:1:2`
+  // not like `C:\\Program Files\node.js\node.exe`
+  if (!/\.m?js:\d+:\d+?$/.test(name)) {
+    return (/\.$/.test(name)) ? { type: 'core' } : { type: 'v8' }
   }
 
-  if (/ native /.test(name)) return { type: 'native' }
-  if (name.indexOf('/') === -1 || (/internal\//.test(name) && !/ \//.test(name))) return { type: 'core' }
-  if (/node_modules/.test(name)) return { type: 'deps' }
+  // Match like `~someFunction native /some/path to/file.js:1:2`
+  // not like `someFunction /some native path/to/file.js:1:2`, windows or posix
+  if (/^[^/\\]* native /.test(name)) return { type: 'native' }
+
+  if (!includesPathSeperator(name) || isInternalPath(name)) return { type: 'core' }
+  if (/\/node_modules\//.test(name) || /\\node_modules\\/.test(name)) return { type: 'deps' }
 
   return { type: 'app' }
 }


### PR DESCRIPTION
- [x] Add static unit tests, testing strings from real profiles
- [x] Add integration tests generating a profile from a fixture
- [x] Fix issues on Mac / Node 11 (tested on 11.3.0 and 11.0.0) 
- [x] Fix issues on Mac / Node 10 (tested on 10.13.0, 10.12.0 and 10.0.0) 
- [x] Fix issues on Mac / Node 8 (tested on 8.13.0)
- [x] Fix issues on Windows / Node 11 (tested on 11.3.0 and 11.0.0) 
- [x] Fix issues on Windows / Node 10 (tested on 10.13.0, 10.12.0 and 10.0.0)  
- [x] Fix issues on Windows / Node 8 (tested on 8.13.0)
- [x] Check where Node 9 sits regarding version-specific issues
- [x] Update against latest master

This does quite a few things:

 - Brings test coverage up, from almost nothing to >~50% on Node 11 (note that `tap --cov` breaks 0x on Node 8):

```
---------------------------|----------|----------|----------|----------|-------------------|
File                       |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
---------------------------|----------|----------|----------|----------|-------------------|
All files                  |    57.48 |    47.77 |    57.01 |    58.18 |                   |
```

 - Adds unit and integration tests for backend log processing and frame naming
 - Adds unit and integration tests for frontend type classification used by the filter buttons
 - Fixes things (all of which are covered in the tests):
   - Fixes https://github.com/davidmarkclements/0x/issues/195 - app and deps are now correctly recognised on windows
   - Refines the fix to https://github.com/davidmarkclements/0x/issues/192 so that it doesn't only fix Windows paths, it also fixes regex definitions containing \\ on all platforms; and since it is now always applied, cuts out a skippable file write
   - Refines that fix so that it doesn't break certain unicode strings that are written in the initial log file as escaped codes like \\u12a3 if they follow a path separator
   - Fixes a several false-positive edge cases in the frontend type classification (things like, folders that contain ' native ', regexes that contain '.js' or any other identifier)
   - Fixes an issue with backslashes and unicode in regex definitions being over-escaped in Node 8 and appearing garbled in the output