### PR TITLE
Add informative error message for known point of failure (observers like Tap coverage on Node 8)

### DIFF
--- a/lib/ticks-to-tree.js
+++ b/lib/ticks-to-tree.js
@@ -3,7 +3,6 @@
 const { spawnSync } = require('child_process')
 const { join } = require('path')
 const debug = require('debug')('0x: ticks-to-tree')
-const assert = require('assert')
 const escape = require('escape-string-regexp')
 
 const preloadDirRx = RegExp(join(escape(__dirname), 'preload'))
@@ -38,7 +37,10 @@ function ticksToTree (ticks, options = {}) {
     stackChild = spawnSync(pathToNodeBinary, stackArgs)
   }
   const stackRegExpStr = stackChild.stdout.toString()
-  assert(stackRegExpStr)
+  if (!stackRegExpStr) {
+    throw new Error('0x/lib/random-require.js returned an empty RegExp string. This may be ' +
+    'because of interference in the child process. One known cause is Tap tests with coverage enabled on Node 8.')
+  }
   const regExp = new RegExp(stackRegExpStr)
 
   ticks.forEach((stack) => {


### PR DESCRIPTION
0x fails in lib/ticks-to-tree.js if it is running inside a Tap test with coverage enabled on Node 8, which causes lib/random-require.js to return an empty string. There are probably other similar scenarios too, where something observing child processes interferes.

The point it fails doesn't give much of a clue about what happened - it's an assert in a file two removed from where the problem actually occurs, and the problem itself happens in random-require.js which is hard to debug because it uses console.log output to communicate with the parent process that calls it. Then quite a leap of logic is needed to link this to the actual cause (e.g. Tap coverage).

So it's helpful to give users and contributors an informative error message at this point.