### PR TITLE
Disable default alphabetical sorting in flamegraph

### DIFF
--- a/visualizer/index.js
+++ b/visualizer/index.js
@@ -18,12 +18,13 @@ module.exports = function (trees, opts) {
   const categorizer = !kernelTracing && graph.v8cats
   const flamegraph = fg({
     categorizer,
-    tree,
+    tree: [],
     exclude: Array.from(exclude),
     element: chart,
     topOffset: 55
   })
   flamegraph.sort(false)
+  flamegraph.renderTree(tree)
   const { colors } = flamegraph
 
   let userZoom = true // false if the last zoom call was initiated by 0x

--- a/visualizer/index.js
+++ b/visualizer/index.js
@@ -23,6 +23,7 @@ module.exports = function (trees, opts) {
     element: chart,
     topOffset: 55
   })
+  flamegraph.sort(false)
   const { colors } = flamegraph
 
   let userZoom = true // false if the last zoom call was initiated by 0x


### PR DESCRIPTION
I figured the entries are in a weird order. Seem like d3-fg sorts nodes by default by name. This doesn't make sense for 0x as node are already in correct (time) order.