### PR TITLE
Skip redirecting stdout for Worker threads

### DIFF
--- a/lib/preload/redir-stdout.js
+++ b/lib/preload/redir-stdout.js
@@ -1,13 +1,21 @@
 'use strict'
 const net = require('net')
 
-const socket = new net.Socket({
-  fd: 3,
-  readable: false,
-  writable: true
-})
-Object.defineProperty(process, 'stdout', {
-  configurable: true,
-  enumerable: true,
-  get: () => socket
-})
+let isWorker = false
+try {
+  // Skip redirecting stdout in Worker threads.
+  isWorker = !require('worker_threads').isMainThread
+} catch (e) {}
+
+if (!isWorker) {
+  const socket = new net.Socket({
+    fd: 3,
+    readable: false,
+    writable: true
+  })
+  Object.defineProperty(process, 'stdout', {
+    configurable: true,
+    enumerable: true,
+    get: () => socket
+  })
+}


### PR DESCRIPTION
This breaks running 0x with Workers, because the internal stdio
implementation for Workers currently relies on `process.stdout`
being the originally provided object.