### PR TITLE
Update isolate log regexes for V8 7.3

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ async function visualize ({ visualizeOnly, treeDebug, workingDir, title, mapFram
       : visualizeOnly
     const ls = fs.readdirSync(folder)
     const traceFile = /^stacks\.(.*)\.out$/
-    const isolateLog = /^isolate-((0x)?[0-9A-Fa-f]{2,16})-(.*)-v8\.(log|json)$/
+    const isolateLog = /^isolate-((0x)?[0-9A-Fa-f]{2,16})(?:-\d*)?-(\d*)-v8\.(log|json)$/
     const stacks = ls.find((f) => isolateLog.test(f) || traceFile.test(f))
     if (!stacks) {
       throw Error('Invalid data path provided (no stacks or v8 log file found)')

--- a/lib/util.js
+++ b/lib/util.js
@@ -54,7 +54,7 @@ function tidy () {
 
   fs.readdirSync('.')
     .filter(function (f) {
-      return /isolate-(0x[0-9A-Fa-f]{2,12})-v8\.log/.test(f)
+      return /isolate-(0x[0-9A-Fa-f]{2,12})(-\d+)?(-\d+)?-v8\.log/.test(f)
     })
     .forEach(function (f) {
       fs.unlinkSync(f)

--- a/platform/v8.js
+++ b/platform/v8.js
@@ -123,7 +123,7 @@ async function v8 (args) {
 
 // Public method so it can be used in external error handlers
 v8.getIsolateLog = function (workingDir, pid) {
-  const regex = new RegExp(`isolate-0(x)?([0-9A-Fa-f]{2,16})-${pid}-v8.log`)
+  const regex = new RegExp(`isolate-0(x)?([0-9A-Fa-f]{2,16})(-${pid})?-${pid}-v8.log`)
   return fs.readdirSync(workingDir).find(regex.test.bind(regex))
 }
 


### PR DESCRIPTION
The isolate log filename from V8 now includes the pid by default, so combined with our
custom `--logfile` pattern it adds the pid twice. This updates the
regexes to account for an optional duplicate pid.