### PR TITLE
Fix init stack regex setup with latest Node master

### DIFF
--- a/lib/ticks-to-tree.js
+++ b/lib/ticks-to-tree.js
@@ -29,7 +29,7 @@ function ticksToTree (ticks, options = {}) {
 
   // Spawn a file that throws an error to get the loading stack.
   // Then create a regular expression that matches all those files.
-  const stackArgs = ['--experimental-modules', '--no-warnings', join(__dirname, 'loading-stacks')]
+  const stackArgs = ['--experimental-modules', '--no-warnings', join(__dirname, 'loading-stacks.js')]
   let stackChild = spawnSync(pathToNodeBinary, stackArgs)
   if (stackChild.stderr.toString().includes('--experimental-modules')) {
     // Future proof to make sure it works even if the `experimental-modules` flag is removed.


### PR DESCRIPTION
I guess the new --experimental-modules implementation changed this
behaviour. Doing `node --experimental-modules ./no-extension` doesn't
do extension probing now, so we have to spell out the `.js`.