### PR TITLE
Fix Node 8 compatibility

### DIFF
--- a/lib/cpu-profile-to-tree.js
+++ b/lib/cpu-profile-to-tree.js
@@ -1,13 +1,12 @@
 'use strict'
 
 function convert (profile) {
-
   const converted = {
     children: new Array(profile.children.length),
     name: `${profile.functionName}${profile.url ? ' ' + profile.url : ''}${profile.lineNumber > 0 ? `:${profile.lineNumber}` : ''}`,
     top: profile.hitCount,
     value: profile.hitCount,
-    S: 0,
+    S: 0
   }
   if (profile.functionName[0] === '(' && profile.children.length === 0) {
     // filter out (garbage collector) and (idle)

--- a/lib/render.js
+++ b/lib/render.js
@@ -1,5 +1,6 @@
 'use strict'
-const { readFile } = require('fs').promises
+const { promisify } = require('util')
+const readFile = promisify(require('fs').readFile)
 const path = require('path')
 const browserify = require('browserify')
 const concat = require('concat-stream')

--- a/visualizer/state.js
+++ b/visualizer/state.js
@@ -22,7 +22,7 @@ module.exports = ({ colors, trees, exclude, merged = false, kernelTracing, title
     unoptimized: false,
     renderMergedBtn: !kernelTracing,
     merged: merged,
-    visualizeCpuProfile,
+    visualizeCpuProfile
   },
   typeFilters: {
     visualizeCpuProfile,


### PR DESCRIPTION
fs.promises is available in Node 10+ only. By using promisify(fs.readFile) instead we stay compatible with Node 8.

Fixes https://github.com/nearform/node-clinic/issues/156
Fixes https://github.com/nearform/node-clinic/issues/157