### PR TITLE
Flag likely wasm stack frames

### DIFF
--- a/lib/ticks-to-tree.js
+++ b/lib/ticks-to-tree.js
@@ -11,6 +11,10 @@ const nodeBootstrapRegExp = / internal\/bootstrap.+\.js:\d+:\d+$/
 
 module.exports = ticksToTree
 
+function hasFileLocation (jsFrameName) {
+  return /:\d+:\d+$/.test(jsFrameName)
+}
+
 function ticksToTree (ticks, options = {}) {
   const { mapFrames, inlined, pathToNodeBinary = process.execPath } = options
   const merged = {
@@ -87,8 +91,13 @@ function ticksToTree (ticks, options = {}) {
             }
           }
         }
+
         if (kind === 'Unopt') S += 1
         else if (kind === 'Opt') S += 2
+
+        if (!hasFileLocation(name)) {
+          type = 'WASM'
+        }
       }
 
       if (type && type !== 'JS') name += ' [' + type + (kind ? ':' + kind : '') + ']'

--- a/visualizer/cmp/graph.js
+++ b/visualizer/cmp/graph.js
@@ -30,6 +30,7 @@ function v8cats (child) {
   if (/\[CODE:RegExp]$/.test(name)) return { type: 'regexp' }
   // Unless we create an eval checkbox, "native" is the next best label - cannot tell if the eval is from app, deps, core
   if (/\[eval]:\d+:\d+$/.test(name)) return { type: 'native' }
+  if (/\[WASM:\w+]$/.test(name)) return { type: 'native' }
 
   if (/\[INIT]$/.test(name)) return { type: 'init' }
   if (/\[INLINABLE]$/.test(name)) return { type: 'inlinable' }

--- a/visualizer/cmp/graph.js
+++ b/visualizer/cmp/graph.js
@@ -30,7 +30,8 @@ function v8cats (child) {
   if (/\[CODE:RegExp]$/.test(name)) return { type: 'regexp' }
   // Unless we create an eval checkbox, "native" is the next best label - cannot tell if the eval is from app, deps, core
   if (/\[eval]:\d+:\d+$/.test(name)) return { type: 'native' }
-  if (/\[WASM:\w+]$/.test(name)) return { type: 'native' }
+  // wasm has no location data either, but typically has lots more frames than [eval], so it gets its very own category
+  if (/\[WASM:\w+]$/.test(name)) return { type: 'wasm' }
 
   if (/\[INIT]$/.test(name)) return { type: 'init' }
   if (/\[INLINABLE]$/.test(name)) return { type: 'inlinable' }

--- a/visualizer/cmp/type-filters.js
+++ b/visualizer/cmp/type-filters.js
@@ -20,6 +20,7 @@ module.exports = (render) => ({ bgs, exclude, enableInlinable, renderInlinable, 
   const app = hoc({ bg: bgs.app, exclude, name: 'app' }, action)
   const deps = hoc({ bg: bgs.deps, exclude, name: 'deps' }, action)
   const core = hoc({ bg: bgs.core, exclude, name: 'core' }, action)
+  const wasm = hoc({ bg: bgs.wasm, exclude, name: 'wasm' }, action)
   const v8 = hoc({ bg: bgs.v8, exclude, name: 'v8' }, action)
   const init = hoc({ bg: bgs.init, exclude, name: 'init' }, action)
   if (visualizeCpuProfile) {
@@ -36,7 +37,7 @@ module.exports = (render) => ({ bgs, exclude, enableInlinable, renderInlinable, 
 
   return render`
     <div style='margin-left:-.25rem'>
-      ${app}${deps}${core}${inlinable}${native}${regexp}${v8}${cpp}${init}
+      ${app}${deps}${core}${wasm}${inlinable}${native}${regexp}${v8}${cpp}${init}
     </div>
   `
 }

--- a/visualizer/state.js
+++ b/visualizer/state.js
@@ -33,6 +33,7 @@ module.exports = ({ colors, trees, exclude, merged = false, kernelTracing, title
       app: '#fff',
       deps: '#fff',
       core: '#fff',
+      wasm: '#fff',
       native: '#fff',
       cpp: '#fff',
       regexp: '#fff',
@@ -59,6 +60,11 @@ module.exports = ({ colors, trees, exclude, merged = false, kernelTracing, title
         colors.core.h,
         colors.core.s / 100 * 1.2,
         colors.core.l / 100 * 1.2
+      )})`,
+      wasm: `rgb(${hsl(
+        colors.wasm.h,
+        colors.wasm.s / 100,
+        colors.wasm.l / 100
       )})`,
       native: `rgb(${hsl(
         colors.native.h,


### PR DESCRIPTION
wasm stack frames are outputted (output? put out?) basically with only their name, and no location data. I tried finding other differences between wasm and JS frames but there don't seem to be any.


This PR marks JS frames that don't have a source location as WASM frames. I'm not 100% sure that is right, but it should be close—Clinic Flame would've crashed in the past on JS frames without a filename and it has seen quite a few projects by now. Do we know if anything else may cause missing location data?

The [WASM] tag allows clinic flame to handle the wasm stack frames specially (eg. by setting a default filename or labelling them differently).

0x already "worked" without this, but wasm frames were categorised as V8 frames, which is quite inaccurate. This categorises wasm frames as "native" instead, which is also not great, but is at least not great in the same way as evals :)