### PR TITLE
Avoid overwriting error if isolate log was not created

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,9 +80,15 @@ async function startProcessAndCollectTraceData (args) {
 
   switch (args.kernelTracing ? platform : 'v8') {
     case 'v8': return v8(args).catch((err) => {
-      const logFilePath = join(args.workingDir, v8.getIsolateLog(args.workingDir, args.pid))
-      let message = 'Fatal error in process observed by 0x. Incomplete V8 isolate log '
+      const logFileName = v8.getIsolateLog(args.workingDir, args.pid)
+      if (!logFileName) {
+        if (!args.quiet && !args.silent) console.warn('Fatal error in process observed by 0x. V8 isolate log not created.')
+        throw err
+      }
 
+      const logFilePath = join(args.workingDir, logFileName)
+
+      let message = 'Fatal error in process observed by 0x. Incomplete V8 isolate log '
       if (process.env.DEBUG && process.env.DEBUG.includes('0x')) {
         message += `is readable for debugging at ${logFilePath}`
       } else {


### PR DESCRIPTION
Previously you would get an error message about `path.join()` here,
which is not that helpful. Instead, rethrow the original error if the
log file does not exist.