### PR TITLE
Add transpiled warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,19 +116,16 @@ function checkForTranspiledCode (filename) {
   let isTranspiled = false
 
   // Check for a source map
-  isTranspiled = readFile.includes('//# sourceMappingURL=')
-
-  while ((matchedObj = regex.exec(readFile)) !== null) {
-    // Avoid infinite loops with zero-width matches
-    if (matchedObj.index === regex.lastIndex) {
-      regex.lastIndex++
-    }
+  if (readFile.includes('//# sourceMappingURL=')) {
+    isTranspiled = true
+  } else {
+    isTranspiled = true
     // Loop through results and check length of fn name
-    matchedObj.forEach((match, groupIndex) => {
-      if (groupIndex !== 0 && match.length < 3) {
-        isTranspiled = true
+    while ((matchedObj = regex.exec(readFile)) !== null) {
+      if (matchedObj[1].length > 3) {
+        isTranspiled = false
       }
-    })
+    }
   }
   return isTranspiled
 }

--- a/index.js
+++ b/index.js
@@ -24,10 +24,6 @@ async function zeroEks (args) {
     args.pathToNodeBinary = pathTo('node')
   }
 
-  if (checkForTranspiledCode(args.argv[0])) {
-    console.warn('Transpiled code is not supported')
-  }
-
   validate(args)
   const { collectOnly, visualizeOnly, writeTicks, treeDebug, mapFrames, visualizeCpuProfile } = args
 
@@ -44,6 +40,11 @@ async function zeroEks (args) {
   if (visualizeCpuProfile) return cpuProfileVisualization(args)
 
   args.title = args.title || `node ${args.argv.join(' ')}`
+
+  if (checkForTranspiledCode(args.argv[0])) {
+    console.warn('0x does not support transpiled code yet.')
+  }
+
   var { ticks, pid, folder, inlined } = await startProcessAndCollectTraceData(args)
 
   if (treeDebug === true) {

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ async function zeroEks (args) {
 
   args.title = args.title || `node ${args.argv.join(' ')}`
 
-  if (checkForTranspiledCode(args.argv[0])) {
+  if (args.argv && checkForTranspiledCode(args.argv[0])) {
     console.warn('0x does not support transpiled code yet.')
   }
 
@@ -110,7 +110,12 @@ async function generateFlamegraph (opts) {
 }
 
 function checkForTranspiledCode (filename) {
-  const readFile = fs.readFileSync(filename, 'utf8')
+  let readFile = null
+  try {
+    readFile = fs.readFileSync(filename, 'utf8')
+  } catch (err) {
+    return false
+  }
   const regex = /function\s+(\w+)/g
   let matchedObj
   let isTranspiled = false

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ async function generateFlamegraph (opts) {
 
 function checkForTranspiledCode (filename) {
   const readFile = fs.readFileSync(filename, 'utf8')
-  const regex = /function\s+(?<functionName>\w+)/g
+  const regex = /function\s+(\w+)/g
   let matchedObj
   let isTranspiled = false
 

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ async function zeroEks (args) {
   }
 
   if (checkForTranspiledCode(args.argv[0])) {
-    throw Error('Transpiled code is not supported')
+    console.warn('Transpiled code is not supported')
   }
 
   validate(args)

--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ const v8LogToTicks = require('./lib/v8-log-to-ticks')
 const ticksToTree = require('./lib/ticks-to-tree')
 const render = require('./lib/render')
 const { pathTo } = require('./lib/util')
-
 const platform = process.platform
 const { tidy, noop, isSudo } = require('./lib/util')
 

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ async function zeroEks (args) {
 
   args.title = args.title || `node ${args.argv.join(' ')}`
 
-  if (args.argv && checkForTranspiledCode(args.argv[0])) {
+  if (Array.isArray(args.argv) && args.argv.length > 0 && checkForTranspiledCode(args.argv[0])) {
     console.warn('0x does not support transpiled code yet.')
   }
 


### PR DESCRIPTION
Detect transpiled code by using a median of function name length and provide warning to the user. Also checks file for a source map comment.