### PR TITLE
fix regex bug of optional 0x prefix

### DIFF
--- a/platform/v8.js
+++ b/platform/v8.js
@@ -123,7 +123,7 @@ async function v8 (args) {
 
 // Public method so it can be used in external error handlers
 v8.getIsolateLog = function (workingDir, pid) {
-  const regex = new RegExp(`isolate-0(x)?([0-9A-Fa-f]{2,16})(-${pid})?-${pid}-v8.log`)
+  const regex = new RegExp(`isolate-(0x)?([0-9A-Fa-f]{2,16})(-${pid})?-${pid}-v8.log`)
   return fs.readdirSync(workingDir).find(regex.test.bind(regex))
 }
 


### PR DESCRIPTION
The bug prevented a file match on a system in which %p or std::ostream&<< doesn't prefix the address with 0x, as on z/OS.

Note the updated regex now also matches the 0x part in index.js visualize().