### PR TITLE
fix: error msg on workingdir

### DIFF
--- a/platform/v8.js
+++ b/platform/v8.js
@@ -25,7 +25,7 @@ async function v8 (args) {
 
   let proc = spawn(pathToNodeBinary, [
     '--prof',
-    `--logfile=%p-v8.log`,
+    `--logfile=${workingDir ? `${args.workingDir}/` : ''}%p-v8.log`,
     '--print-opt-source',
     '-r', path.join(__dirname, '..', 'lib', 'preload', 'no-cluster'),
     '-r', path.join(__dirname, '..', 'lib', 'preload', 'redir-stdout'),

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,4 +1,4 @@
-const path = require('path')
+const { resolve } = require('path')
 const { test } = require('tap')
 
 test('module loads', function (t) {
@@ -10,8 +10,8 @@ test('module loads', function (t) {
 test('accepts different workingDir', async t => {
   const zeroEks = require('../')
   const opts = {
-    argv: [path.join(__dirname, 'fixture', 'do-eval.js')],
-    workingDir: path.join(__dirname, '..', 'test.0x')
+    argv: [ resolve(__dirname, './fixture/do-eval.js') ],
+    workingDir: resolve('../test.0x')
   }
   const file = zeroEks(opts)
   t.resolves(file)

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -11,7 +11,7 @@ test('accepts different workingDir', async t => {
   const zeroEks = require('../')
   const opts = {
     argv: [ resolve(__dirname, './fixture/do-eval.js') ],
-    workingDir: resolve('../test.0x')
+    workingDir: resolve('./')
   }
   const file = zeroEks(opts)
   t.resolves(file)

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,7 +1,19 @@
+const path = require('path')
 const { test } = require('tap')
 
 test('module loads', function (t) {
   require('../')
   t.pass('0x loaded')
+  t.end()
+})
+
+test('accepts different workingDir', async t => {
+  const zeroEks = require('../')
+  const opts = {
+    argv: [path.join(__dirname, 'fixture', 'do-eval.js')],
+    workingDir: path.join(__dirname, '..', 'test.0x')
+  }
+  const file = zeroEks(opts)
+  t.resolves(file)
   t.end()
 })


### PR DESCRIPTION
When using the API, and specifying a different `workingDir`, the process crashes with the following error:

`TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type undefined`

It was originally reported in issue #228 and and fixed in PR #229 but a test is still missing to get it merged.
This PR applies the same fix, and adds a test to validate the error does not occur anymore.