### PR TITLE
Collect timeout feature

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -60,13 +60,13 @@ async function cmd (argv, banner = defaultBanner) {
       visualizeOnly: 'visualize-only',
       visualizeCpuProfile: 'visualize-cpu-profile',
       collectOnly: 'collect-only',
+      collectDelay: 'collect-delay',
       kernelTracing: 'kernel-tracing',
       kernelTracingDebug: 'kernel-tracing-debug',
       treeDebug: 'tree-debug',
       writeTicks: 'write-ticks',
       onPort: 'on-port',
-      P: 'onPort',
-      collectDelay: 'on-timeout'
+      P: 'onPort'
     }
   })
 

--- a/cmd.js
+++ b/cmd.js
@@ -65,7 +65,8 @@ async function cmd (argv, banner = defaultBanner) {
       treeDebug: 'tree-debug',
       writeTicks: 'write-ticks',
       onPort: 'on-port',
-      P: 'onPort'
+      P: 'onPort',
+      collectDelay: 'on-timeout'
     }
   })
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -59,6 +59,12 @@ with relevant outputs.
 
 Default: false
 
+#### `collectDelay` (number)
+
+Specify a delay(ms) before collecting data.
+
+Default: 0
+
 #### `mapFrames` (function)
 
 A custom mapping function that receives 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ async function zeroEks (args) {
   if (args.pathToNodeBinary === 'node') {
     args.pathToNodeBinary = pathTo('node')
   }
-  
+
   args.collectDelay = args.collectDelay || 0
 
   validate(args)
@@ -66,7 +66,7 @@ async function zeroEks (args) {
   }
 
   if (collectDelay) {
-    debug('data collection will be delayed by '+timeoutDelay+' ms')
+    debug('data collection will be delayed by ' + collectDelay + ' ms')
   }
 
   try {

--- a/index.js
+++ b/index.js
@@ -151,7 +151,7 @@ async function visualize ({ visualizeOnly, treeDebug, workingDir, title, mapFram
     name = name || meta.name
 
     const ticks = (srcType === 'v8')
-      ? await v8LogToTicks(src, pathToNodeBinary)
+      ? await v8LogToTicks(src, { pathToNodeBinary })
       : traceStacksToTicks(src)
 
     if (treeDebug === true) {

--- a/index.js
+++ b/index.js
@@ -24,9 +24,11 @@ async function zeroEks (args) {
   if (args.pathToNodeBinary === 'node') {
     args.pathToNodeBinary = pathTo('node')
   }
+  
+  args.collectDelay = args.collectDelay || 0
 
   validate(args)
-  const { collectOnly, visualizeOnly, writeTicks, treeDebug, mapFrames, visualizeCpuProfile } = args
+  const { collectOnly, visualizeOnly, writeTicks, treeDebug, mapFrames, visualizeCpuProfile, collectDelay } = args
 
   let incompatibleOptions = 0
   if (collectOnly) incompatibleOptions += 1
@@ -61,6 +63,10 @@ async function zeroEks (args) {
     tidy()
     debug('done')
     return folder
+  }
+
+  if (collectDelay) {
+    debug('data collection will be delayed by '+timeoutDelay+' ms')
   }
 
   try {

--- a/lib/v8-log-to-ticks.js
+++ b/lib/v8-log-to-ticks.js
@@ -119,11 +119,16 @@ function v8LogToTicks (isolateLogPath, options) {
       close()
     })
 
+    const firstTick = [];
     const tickStream = parse('ticks.*', (tick) => {
       const addr = tick.s.filter((n, i) => i % 2 === 0)
       var stack = addr.map((n) => codes[n]).filter(Boolean)
       const delayMs = options.collectDelay * 1000
-      if (tick.tm > (tick.tm+delayMs)) {
+      if(firstTick.length===0) {
+        firstTick.push(tick.tm);
+      }
+      // Compare ticks to first for collectDelay
+      if (tick.tm > (firstTick[0]+delayMs)) {
         ticks.push(stack.reverse())
       }
     })

--- a/lib/v8-log-to-ticks.js
+++ b/lib/v8-log-to-ticks.js
@@ -15,9 +15,9 @@ const nodeMajorV = Number(process.versions.node.split('.')[0])
 
 module.exports = wrapper
 
-async function wrapper (isolateLogPath, node) {
+async function wrapper (isolateLogPath, options) {
   const normalised = await prepareForPreprocess(isolateLogPath)
-  return v8LogToTicks(normalised, node)
+  return v8LogToTicks(normalised, options)
 }
 
 // 1. Filter because long lines make the --preprocess crash. Filter them beforehand,
@@ -67,9 +67,9 @@ function fixLines (line) {
   }
 }
 
-function v8LogToTicks (isolateLogPath, node) {
+function v8LogToTicks (isolateLogPath, options) {
   const isJson = extname(isolateLogPath) === '.json'
-  const sp = isJson || spawn(node.pathToNodeBinary, [
+  const sp = isJson || spawn(options.pathToNodeBinary, [
     '--prof-process', '--preprocess', isolateLogPath
   ], { stdio: ['ignore', 'pipe', 'pipe'] })
 
@@ -122,7 +122,7 @@ function v8LogToTicks (isolateLogPath, node) {
     const tickStream = parse('ticks.*', (tick) => {
       const addr = tick.s.filter((n, i) => i % 2 === 0)
       var stack = addr.map((n) => codes[n]).filter(Boolean)
-      const delayMs = node.collectDelay * 1000
+      const delayMs = options.collectDelay * 1000
       if (tick.tm > delayMs) {
         ticks.push(stack.reverse())
       }

--- a/lib/v8-log-to-ticks.js
+++ b/lib/v8-log-to-ticks.js
@@ -120,10 +120,10 @@ function v8LogToTicks (isolateLogPath, options) {
     })
 
     const firstTick = []
+    const delayMs = options.collectDelay * 1000;
     const tickStream = parse('ticks.*', (tick) => {
       const addr = tick.s.filter((n, i) => i % 2 === 0)
       var stack = addr.map((n) => codes[n]).filter(Boolean)
-      const delayMs = options.collectDelay * 1000
       if (firstTick.length === 0) {
         firstTick.push(tick.tm)
       }

--- a/lib/v8-log-to-ticks.js
+++ b/lib/v8-log-to-ticks.js
@@ -123,7 +123,7 @@ function v8LogToTicks (isolateLogPath, options) {
       const addr = tick.s.filter((n, i) => i % 2 === 0)
       var stack = addr.map((n) => codes[n]).filter(Boolean)
       const delayMs = options.collectDelay * 1000
-      if (tick.tm > delayMs) {
+      if (tick.tm > (tick.tm+delayMs)) {
         ticks.push(stack.reverse())
       }
     })

--- a/lib/v8-log-to-ticks.js
+++ b/lib/v8-log-to-ticks.js
@@ -69,7 +69,7 @@ function fixLines (line) {
 
 function v8LogToTicks (isolateLogPath, node) {
   const isJson = extname(isolateLogPath) === '.json'
-  const sp = isJson || spawn(node, [
+  const sp = isJson || spawn(node.pathToNodeBinary, [
     '--prof-process', '--preprocess', isolateLogPath
   ], { stdio: ['ignore', 'pipe', 'pipe'] })
 
@@ -122,7 +122,10 @@ function v8LogToTicks (isolateLogPath, node) {
     const tickStream = parse('ticks.*', (tick) => {
       const addr = tick.s.filter((n, i) => i % 2 === 0)
       var stack = addr.map((n) => codes[n]).filter(Boolean)
-      ticks.push(stack.reverse())
+      const delayMs = node.collectDelay * 1000
+      if (tick.tm > delayMs) {
+        ticks.push(stack.reverse())
+      }
     })
 
     pump(srcStream, tickStream, (err) => {

--- a/lib/v8-log-to-ticks.js
+++ b/lib/v8-log-to-ticks.js
@@ -119,16 +119,16 @@ function v8LogToTicks (isolateLogPath, options) {
       close()
     })
 
-    const firstTick = [];
+    const firstTick = []
     const tickStream = parse('ticks.*', (tick) => {
       const addr = tick.s.filter((n, i) => i % 2 === 0)
       var stack = addr.map((n) => codes[n]).filter(Boolean)
       const delayMs = options.collectDelay * 1000
-      if(firstTick.length===0) {
-        firstTick.push(tick.tm);
+      if (firstTick.length === 0) {
+        firstTick.push(tick.tm)
       }
       // Compare ticks to first for collectDelay
-      if (tick.tm > (firstTick[0]+delayMs)) {
+      if (tick.tm > (firstTick[0] + delayMs)) {
         ticks.push(stack.reverse())
       }
     })

--- a/platform/v8.js
+++ b/platform/v8.js
@@ -21,7 +21,7 @@ const {
 module.exports = v8
 
 async function v8 (args) {
-  const { status, outputDir, workingDir, name, onPort, pathToNodeBinary } = args
+  const { status, outputDir, workingDir, name, onPort, pathToNodeBinary, collectDelay } = args
 
   let proc = spawn(pathToNodeBinary, [
     '--prof',
@@ -114,7 +114,7 @@ async function v8 (args) {
   const isolateLogPath = path.join(folder, isolateLog)
   await renameSafe(path.join(args.workingDir, isolateLog), isolateLogPath)
   return {
-    ticks: await v8LogToTicks(isolateLogPath, pathToNodeBinary),
+    ticks: await v8LogToTicks(isolateLogPath, { pathToNodeBinary, collectDelay }),
     inlined: inlined,
     pid: proc.pid,
     folder: folder

--- a/readme.md
+++ b/readme.md
@@ -226,6 +226,12 @@ with relevant outputs.
 
 Default: false
 
+### --collect-delay
+
+Delay the collection of stacks by a specified time(ms) relative to the first entry.
+
+Default: 0
+
 ### --visualize-only
 
 Supply a path to a profile folder to build or rebuild visualization

--- a/schema.json
+++ b/schema.json
@@ -101,6 +101,9 @@
     "P": {
       "type": "string"
     },
+    "collectDelay": {
+      "type": "number"
+    },
      "kernelTracing": {
       "type": "boolean"
     },

--- a/schema.json
+++ b/schema.json
@@ -101,6 +101,9 @@
     "P": {
       "type": "string"
     },
+    "collect-delay": {
+      "type": "number"
+    },
     "collectDelay": {
       "type": "number"
     },

--- a/usage.txt
+++ b/usage.txt
@@ -66,6 +66,9 @@
 
   --collect-only          Do not process captured stacks into a flamegraph.
 
+  --collect-delay         Specify a delay(ms) before collecting data.
+
+
   --visualize-only <dir>  Build or rebuild flamegraph using the output dir.
                           Counterpart to --collect-only.
 


### PR DESCRIPTION
Original PR is here: https://github.com/davidmarkclements/0x/pull/222

> For 0x the delay won't hold up the process but rather filter the data depending on the delay value passed in. Open to feedback and further changes/suggestions.

This as the effect of only rendering flamegraphs with data after the delay ends. 

This solves some use cases of https://github.com/davidmarkclements/0x/issues/129. 
My own use case is not wanting to see output from the initial boot of my app (different problem, distracting!) but rather focus on what happens when requests are received. 

I am aware the code is untested, keen for some input on where to start with adding tests as the critical affected code in  lib/v8-log-to-ticks.js appears to be as yet untested as far as I can tell.