### PR TITLE
Adding the SIGTERM to soft exit

### DIFF
--- a/lib/preload/soft-exit.js
+++ b/lib/preload/soft-exit.js
@@ -1,3 +1,9 @@
 'use strict'
 
-process.on('SIGINT', process.exit)
+const SOFT_EXIT_SIGNALS = ['SIGINT', 'SIGTERM']
+
+for (let i = 0; i < SOFT_EXIT_SIGNALS.length; i++) {
+  process.on(SOFT_EXIT_SIGNALS[i], process.exit)
+}
+
+module.exports = { SOFT_EXIT_SIGNALS }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "0x",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "🔥 single-command flamegraph profiling 🔥",
   "main": "index.js",
   "bin": "./cmd.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "0x",
-  "version": "5.0.1",
+  "version": "5.0.0",
   "description": "🔥 single-command flamegraph profiling 🔥",
   "main": "index.js",
   "bin": "./cmd.js",

--- a/readme.md
+++ b/readme.md
@@ -63,11 +63,11 @@ Pass custom arguments to node:
 
 ## Generating
 
-When ready to generate a flamegraph, send a SIGINT.
+When ready to generate a flamegraph, send a SIGINT or a SIGTERM.
 
 The simplest way to do this is pressing CTRL+C.
 
-When `0x` catches the SIGINT, it process the stacks and
+When `0x` catches the SIGINT or the SIGTERM, it process the stacks and
 generates a profile folder (`<pid>.0x`), containing `flamegraph.html`.
 
 ## The UI


### PR DESCRIPTION
When I was using  docker-compose I could not generate the flame-graph because the default signal sent by docker-compose is SIGTERM, there are ways to send SIGINT instead of SIGTERM but that adds more complexity to the docker-compose file, and since SIGTERM is not a force exit signal I think that it should be handled the same way that SIGINT is.