### PR TITLE
fix: add support to inlined functions + sparkplug on v16+

### DIFF
--- a/lib/ticks-to-tree.js
+++ b/lib/ticks-to-tree.js
@@ -6,8 +6,7 @@ const debug = require('debug')('0x: ticks-to-tree')
 const escape = require('escape-string-regexp')
 
 const preloadDirRx = RegExp(join(escape(__dirname), 'preload'))
-// TODO(@rafaelgss): it looks like not working with v16 when node prefix was added
-const internalModuleRegExp = /^.?(?:\(anonymous\)|internalBinding|NativeModule[^ ]*) [^/\\][a-zA-Z0-9_/\\-]+\.js:\d+:\d+$/
+const internalModuleRegExp = /^.?(?:\(anonymous\)|internalBinding|NativeModule[^ ]*) (node:)?[^/\\][a-zA-Z0-9_/\\-]+(\.js)?:\d+:\d+$/
 const nodeBootstrapRegExp = / (node:)?internal\/bootstrap.+(\.js)?:\d+(:?\d+)$/
 
 module.exports = ticksToTree
@@ -64,9 +63,8 @@ function ticksToTree (ticks, options = {}) {
 
       if (type === 'JS') {
         if (name[0] === ' ') name = '(anonymous)' + name
-        // TODO(@rafaelgss): adjust it for v16 + perf stacks
         if (inlineInfo === true) {
-          const [key] = name.split(':')
+          const [key] = name.split(/:[0-9]+:[0-9]+/)
           const info = inlined[key]
           if (info !== undefined) {
             const sameFn = info.length === 1 || info.every(({ pos }, ix) => {
@@ -95,7 +93,10 @@ function ticksToTree (ticks, options = {}) {
           }
         }
 
-        if (kind === 'Unopt') S += 1
+        // Sparkplug is a new baseline, non-optimising second-tier compiler,
+        // designed to fit in the compiler trade-off space between Ignition and
+        // TurboProp/TurboFan.
+        if (kind === 'Unopt' || kind === 'Baseline') S += 1
         else if (kind === 'Opt') S += 2
 
         if (!hasFileLocation(name)) {


### PR DESCRIPTION
I'm still looking if there is something missing because looks like the call stack are not completely correct. 

By the way, I'm running this fork: https://github.com/RafaelGSS/slow-rest-api

```console
node ../node-clinic/bin.js flame --on-port='npm run test' -- node index.js
```

and I'm getting the graph attached

![image](https://user-images.githubusercontent.com/26234614/151249341-8eb1de0a-3cf7-46f4-baad-4f904b82774b.png)

Look that `payload` function is side by side of `a`/`b`/`c`/ function which is its caller

![image](https://user-images.githubusercontent.com/26234614/151250161-9ed1ca83-4b24-45d3-8c6a-991275c77f1f.png)

Does that is acceptable? @mcollina


[204430.clinic-flame.zip](https://github.com/davidmarkclements/0x/files/7945683/204430.clinic-flame.zip)


