### PR TITLE
fix: collect-only to render-only flow

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,12 +123,12 @@ async function cpuProfileVisualization (opts) {
   return file
 }
 
-async function visualize ({ visualizeOnly, treeDebug, workingDir, title, mapFrames, open, name, pathToNodeBinary }) {
+async function visualize ({ visualizeOnly, treeDebug, workingDir, title, mapFrames, open, name, pathToNodeBinary, collectDelay }) {
   try {
     const folder = getFolder(visualizeOnly, workingDir)
     const ls = fs.readdirSync(folder)
     const traceFile = /^stacks\.(.*)\.out$/
-    const isolateLog = /^isolate-((0x)?[0-9A-Fa-f]{2,16})(?:-\d*)?-(\d*)-v8\.(log|json)$/
+    const isolateLog = /^isolate-((?:0x)?[0-9A-Fa-f]{2,16})(?:-\d*)?-(\d*)-v8\.(log|json)$/
     const stacks = ls.find((f) => isolateLog.test(f) || traceFile.test(f))
     if (!stacks) {
       throw Error('Invalid data path provided (no stacks or v8 log file found)')
@@ -151,7 +151,7 @@ async function visualize ({ visualizeOnly, treeDebug, workingDir, title, mapFram
     name = name || meta.name
 
     const ticks = (srcType === 'v8')
-      ? await v8LogToTicks(src, { pathToNodeBinary })
+      ? await v8LogToTicks(src, { pathToNodeBinary, collectDelay })
       : traceStacksToTicks(src)
 
     if (treeDebug === true) {


### PR DESCRIPTION
In v8-log-to-ticks.js:152
```
const delayMs = options.collectDelay * 1000
...
// Compare ticks to first for collectDelay
if (tick.tm > (firstTick[0] + delayMs)) {
  ticks.push(stack.reverse())
}
```
But without this change, `collectDelay` is `NaN` so `firstTick[0] + NaN` ends up `NaN`, which always returns false when compared to a number, so this never resolves to true, and no ticks get added.