### PR TITLE
fix: call soft close instead of process.exit when CTRL + C is pressed

### DIFF
--- a/lib/preload/soft-exit.js
+++ b/lib/preload/soft-exit.js
@@ -1,9 +1,4 @@
 'use strict'
 
-const SOFT_EXIT_SIGNALS = ['SIGINT', 'SIGTERM']
-
-for (let i = 0; i < SOFT_EXIT_SIGNALS.length; i++) {
-  process.on(SOFT_EXIT_SIGNALS[i], process.exit)
-}
-
-module.exports = { SOFT_EXIT_SIGNALS }
+process.on('SIGINT', process.exit)
+process.on('SIGTERM', process.exit)

--- a/platform/linux.js
+++ b/platform/linux.js
@@ -6,8 +6,6 @@ const debug = require('debug')('0x')
 const traceStacksToTicks = require('../lib/trace-stacks-to-ticks')
 const { promisify } = require('util')
 
-const { SOFT_EXIT_SIGNALS } = require('../lib/preload/soft-exit')
-
 const {
   getTargetFolder,
   tidy,
@@ -17,6 +15,8 @@ const {
 } = require('../lib/util')
 
 module.exports = promisify(linux)
+
+const SOFT_EXIT_SIGNALS = ['SIGINT', 'SIGTERM']
 
 function linux (args, sudo, cb) {
   const { status, outputDir, workingDir, name, onPort, pathToNodeBinary } = args

--- a/platform/v8.js
+++ b/platform/v8.js
@@ -12,8 +12,6 @@ const { promisify } = require('util')
 const rename = promisify(fs.rename)
 const sleep = promisify(setTimeout)
 
-const { SOFT_EXIT_SIGNALS } = require('../lib/preload/soft-exit')
-
 const {
   getTargetFolder,
   spawnOnPort,
@@ -21,6 +19,8 @@ const {
 } = require('../lib/util')
 
 module.exports = v8
+
+const SOFT_EXIT_SIGNALS = ['SIGINT', 'SIGTERM']
 
 async function v8 (args) {
   const { status, outputDir, workingDir, name, onPort, pathToNodeBinary, collectDelay } = args


### PR DESCRIPTION
0x is not generating the flame graph when `CTRL + C` is pressed.

It is due to the process end up having two listeners for the `SIGINT` signal `[process.exit, softClose]`.

This could also fix the issue on https://github.com/clinicjs/node-clinic-flame/issues/161