### PR TITLE
cpu-profile-to-tree: Refactor out the filtering of parenthesized nodes

### DIFF
--- a/lib/cpu-profile-to-tree.js
+++ b/lib/cpu-profile-to-tree.js
@@ -1,20 +1,27 @@
 'use strict'
 
-function convert (profile) {
+// Filter out all parenthesized nodes with no children i.e. (idle), (garbage
+// collector) and (program)
+function filterParenthesizedNoChild (profileNode, convertedNode) {
+  const name = profileNode.functionName ?? profileNode.callFrame.functionName
+  const childrenLength = profileNode.children?.length ?? 0
+  if (name[0] === '(' && childrenLength === 0) {
+    convertedNode.top = 0
+    convertedNode.value = 0
+  }
+}
+
+function convert (node) {
   const converted = {
-    children: new Array(profile.children.length),
-    name: `${profile.functionName}${profile.url ? ' ' + profile.url : ''}${profile.lineNumber > 0 ? `:${profile.lineNumber}` : ''}`,
-    top: profile.hitCount,
-    value: profile.hitCount,
+    children: new Array(node.children.length),
+    name: `${node.functionName}${node.url ? ' ' + node.url : ''}${node.lineNumber > 0 ? `:${node.lineNumber}` : ''}`,
+    top: node.hitCount,
+    value: node.hitCount,
     S: 0
   }
-  if (profile.functionName[0] === '(' && profile.children.length === 0) {
-    // filter out (garbage collector) and (idle)
-    converted.top = 0
-    converted.value = 0
-  }
-  for (let i = 0; i < profile.children.length; i++) {
-    converted.children[i] = convert(profile.children[i])
+  filterParenthesizedNoChild(node, converted)
+  for (let i = 0; i < node.children.length; i++) {
+    converted.children[i] = convert(node.children[i])
     converted.value += converted.children[i].value
   }
 
@@ -35,7 +42,7 @@ function convertCpuProf (nodes, id2Index, id) {
   const name = node.callFrame.functionName
   const url = node.callFrame.url
   const lineNumber = node.callFrame.lineNumber
-  const childrenLength = node.children ? node.children.length : 0
+  const childrenLength = node.children?.length ?? 0
   const converted = {
     children: new Array(childrenLength),
     name: `${name}${url ? ' ' + url : ''}${lineNumber > 0 ? `:${lineNumber}` : ''}`,
@@ -43,11 +50,7 @@ function convertCpuProf (nodes, id2Index, id) {
     value: node.hitCount,
     S: 0
   }
-  if (name[0] === '(' && childrenLength === 0) {
-    // filter out (garbage collector) and (idle)
-    converted.top = 0
-    converted.value = 0
-  }
+  filterParenthesizedNoChild(node, converted)
   for (let i = 0; i < childrenLength; i++) {
     converted.children[i] = convertCpuProf(nodes, id2Index, node.children[i])
     converted.value += converted.children[i].value

--- a/lib/cpu-profile-to-tree.js
+++ b/lib/cpu-profile-to-tree.js
@@ -3,8 +3,11 @@
 // Filter out all parenthesized nodes with no children i.e. (idle), (garbage
 // collector) and (program)
 function filterParenthesizedNoChild (profileNode, convertedNode) {
-  const name = profileNode.functionName ?? profileNode.callFrame.functionName
-  const childrenLength = profileNode.children?.length ?? 0
+  let name = profileNode.functionName
+  if (!name) {
+    name = profileNode.callFrame.functionName
+  }
+  const childrenLength = profileNode.children ? profileNode.children.length : 0
   if (name[0] === '(' && childrenLength === 0) {
     convertedNode.top = 0
     convertedNode.value = 0
@@ -42,7 +45,7 @@ function convertCpuProf (nodes, id2Index, id) {
   const name = node.callFrame.functionName
   const url = node.callFrame.url
   const lineNumber = node.callFrame.lineNumber
-  const childrenLength = node.children?.length ?? 0
+  const childrenLength = node.children ? node.children.length : 0
   const converted = {
     children: new Array(childrenLength),
     name: `${name}${url ? ' ' + url : ''}${lineNumber > 0 ? `:${lineNumber}` : ''}`,

--- a/test/cpu-profile-to-tree.test.js
+++ b/test/cpu-profile-to-tree.test.js
@@ -47,6 +47,17 @@ const exampleProfile = {
             children: []
           }
         ]
+      },
+      {
+        functionName: '(idle)',
+        url: '',
+        lineNumber: 0,
+        callUID: 249,
+        bailoutReason: '',
+        id: 39,
+        scriptId: 0,
+        hitCount: 3678,
+        children: []
       }
     ]
   }
@@ -74,6 +85,13 @@ const _expected = {
       name: 'first_function one.js:64',
       top: 0,
       value: 10,
+      S: 0
+    },
+    {
+      children: [],
+      name: '(idle)',
+      top: 0,
+      value: 0,
       S: 0
     }
   ],
@@ -118,7 +136,7 @@ const exampleCpuProfProfile = {
         columnNumber: -1
       },
       hitCount: 0,
-      children: [2]
+      children: [2, 5]
     },
     {
       id: 3,
@@ -142,6 +160,17 @@ const exampleCpuProfProfile = {
       },
       hitCount: 2,
       children: [3, 4]
+    },
+    {
+      id: 5,
+      callFrame: {
+        functionName: '(garbage collector)',
+        scriptId: 0,
+        url: '',
+        lineNumber: -1,
+        columnNumber: -1
+      },
+      hitCount: 766
     }
   ]
 }
@@ -168,6 +197,13 @@ const _expectedCpuProf = {
       name: 'main one.js:63',
       top: 2,
       value: 12,
+      S: 0
+    },
+    {
+      children: [],
+      name: '(garbage collector)',
+      top: 0,
+      value: 0,
       S: 0
     }
   ],


### PR DESCRIPTION
This pr refactors out the code that does the filtering of parenthesized nodes like `(idle)` and `(garbage collector)` in `cpu-profile-to-tree.js`, as well as doing some related cleanup and testing.

As a side note, it appears that `(program)` [refers to V8 infrastructure code](https://github.com/nodejs/node/blob/61c7103ed06e5364eddae4586f90ee97531e14a6/deps/v8/src/profiler/symbolizer.cc#L28-L38) and that `(idle)`, `(garbage collector)` and `(program)` are guaranteed [not to have any children](https://github.com/nodejs/node/blob/61c7103ed06e5364eddae4586f90ee97531e14a6/deps/v8/src/profiler/symbolizer.cc#L172-L181) but this does assume that I'm reading the code correctly and that conclusions made on Node's V8 code is generalizable to other V8 implementations.