### PR TITLE
Update `--visualize-cpu-profile` docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -230,9 +230,9 @@ Default: undefined
 
 ### --visualize-cpu-profile
 
-Supply a path to a CPU profile. See `examples/cpu-profile` for an example.
+Supply a path to a CPU profile (`.cpuprofile`). See `examples/cpu-profile` for examples.
 
-[CPU Profile](https://developers.google.com/web/tools/chrome-devtools/rendering-tools/js-execution) output does not have as much information but it can be exported from Chrome Devtools in the browser. There's also an automated headless tool for doing so: [automated-chrome-profiling](https://github.com/paulirish/automated-chrome-profiling). For creating Node.js Cpu Profiles in Node see [v8-profiler](https://github.com/node-inspector/v8-profiler) or [v8-profiler-next](https://github.com/hyj1991/v8-profiler-next).
+[CPU Profile](https://developers.google.com/web/tools/chrome-devtools/rendering-tools/js-execution) output does not have as much information but it can be exported from Chrome Devtools in the browser. There's also an automated headless tool for doing so: [automated-chrome-profiling](https://github.com/paulirish/automated-chrome-profiling). For creating Node.js Cpu Profiles in Node see [v8-profiler](https://github.com/node-inspector/v8-profiler) or [v8-profiler-next](https://github.com/hyj1991/v8-profiler-next). They can also be generated from Node.js 12 and above using the command-line flag [`--cpu-prof`](https://github.com/nodejs/node/commit/e0e308448240260c207958dfc3dd9245d903af85).
 
 Default: undefined
 

--- a/usage.txt
+++ b/usage.txt
@@ -1,15 +1,15 @@
   --open | -o             Automatically open after finishing
-                          
+
                           Default: false
 
   --on-port | -P          Run a given command and then generate
                           the flamegraph. The command as specified
-                          has access to a $PORT variable. 
+                          has access to a $PORT variable.
                           The $PORT variable is set according
-                          to the first port that profiled process 
-                          opens. 
+                          to the first port that profiled process
+                          opens.
 
-                          Example: 
+                          Example:
                           0x -P 'autocannon localhost:$PORT' app.js
 
                           Note: Remember to use single quotes or else
@@ -19,49 +19,49 @@
 
 
   -q | --quiet            Only output flamegraph URI, and fatal errors.
-                          
+
                           Default: false
 
   -s | --silent           Complete silence, 0x will not output anything,
                           other than fatal errors.
-                          
+
                           Default: false
 
-  --kernel-tracing        Use an OS kernel tracing tool (perf on Linux or 
-                          dtrace on macOs and Solaris). This will capture 
-                          native stack frames (C++ modules and Libuv I/O), 
+  --kernel-tracing        Use an OS kernel tracing tool (perf on Linux or
+                          dtrace on macOs and Solaris). This will capture
+                          native stack frames (C++ modules and Libuv I/O),
                           but may result in missing stacks on Node 8.
-                          
+
                           Default: false
 
 
 
   --output-dir | -D       Specify artifact output directory.
                           Template variables {outputDir}, {pid}, {timestamp}, {cwd}
-                          (current working directory) and {name} 
+                          (current working directory) and {name}
                           (based on the --name flag) are supported.
 
                           Default: '{pid}.0x'
 
   --output-html | -F      Specify destination path for the flamegraph HTML file.
                           Template variables {outputDir}, {pid}, {timestamp}, {cwd}
-                          (current working directory) and {name} 
-                          (based on the --name flag) are supported. 
+                          (current working directory) and {name}
+                          (based on the --name flag) are supported.
                           May also be set to - to send HTML file to STDOUT (note
-                          due to the nature of CLI argument parsing, this must be 
+                          due to the nature of CLI argument parsing, this must be
                           set using =, e.g. --output-html=-).
 
-                          If either this flag or --name is set to - then the HTML 
-                          will go to STDOUT. 
-                           
+                          If either this flag or --name is set to - then the HTML
+                          will go to STDOUT.
+
                           Default: '{outputDir}/{name}.html'
 
-  --kernel-tracing-debug  Show output from dtrace or perf tools. 
-                          
+  --kernel-tracing-debug  Show output from dtrace or perf tools.
+
                           Default: false
 
   --tree-debug            Output a JSON file of stacks as {outputDir}/stacks.{pid}.json
-                          
+
                           Default: false
 
   --collect-only          Do not process captured stacks into a flamegraph.
@@ -74,16 +74,16 @@
 
   --name                  The name of the HTML file, without the .html extension
                           Can be set to - to write HTML to STDOUT (note
-                          due to the nature of CLI argument parsing, this must 
+                          due to the nature of CLI argument parsing, this must
                           be set using =, e.g. --name=-)
 
-                          If either this flag or --output-html is set to - 
+                          If either this flag or --output-html is set to -
                           then the HTML will go to STDOUT.
 
                           Default: flamegraph
 
   --title                 Set the title to display in the flamegraph UI
-                          
+
                           Default: node [nodeFlags] script.js
 
   -v | --version          Output the 0x version

--- a/usage.txt
+++ b/usage.txt
@@ -72,6 +72,9 @@
   --visualize-only <dir>  Build or rebuild flamegraph using the output dir.
                           Counterpart to --collect-only.
 
+  --visualize-cpu-profile Visualize a .cpuprofile file. See examples at
+                          `examples/cpu-profile`.
+
   --name                  The name of the HTML file, without the .html extension
                           Can be set to - to write HTML to STDOUT (note
                           due to the nature of CLI argument parsing, this must


### PR DESCRIPTION
This pr updates the documentation for the `--visualize-cpu-profile` flag in `readme.md` and `usage.txt`. It also removes trailing spaces from `usage.txt`.