### PR TITLE
Fix: EXDEV: cross-device link not permitted

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "env-string": "^1.0.0",
     "escape-string-regexp": "^4.0.0",
     "execspawn": "^1.0.1",
+    "fs-extra": "^10.1.0",
     "has-unicode": "^2.0.1",
     "hsl-to-rgb-for-reals": "^1.1.0",
     "jsonstream2": "^3.0.0",

--- a/platform/v8.js
+++ b/platform/v8.js
@@ -147,7 +147,7 @@ async function renameSafe (from, to, tries = 0) {
       throw e
     }
     await sleep(1000)
-    await renameSafe(from, to, tries++)
+    await renameSafe(from, to, tries + 1)
   }
 }
 


### PR DESCRIPTION
It's impossible to use 0x with volumes mounted on different file systems.

```
Error: 
EXDEV: cross-device link not permitted, rename '/dir1/isolate-0x2f2a329ae330-418-418-v8.log' -> '/dir2/isolate-0x2f2a329ae330-418-418-v8.log'
```

The reason of such behavior is `fs.rename`. So I added `fs-extra` and use `move` instead.

P.S. Also, there was infinity loop in `renameSafe`. This is because of `i++` :see_no_evil: 

Probably fix https://github.com/davidmarkclements/0x/issues/241