### PR TITLE
update: add on-port check when kernel-tracing

### DIFF
--- a/docs/kernel-tracing.md
+++ b/docs/kernel-tracing.md
@@ -20,6 +20,10 @@ enabled on macOS.
 0x --kernel-tracing my-app.js
 ```
 
+> Note: `0x` uses `linux_perf` for kernel tracing, which requires spawning a non-nodejs process
+directly, for this reason, one can't use `--kernel-tracing` together with `--on-port`. Instead,
+run it in a separate terminal.
+
 ## Troubleshooting
 
 ### Missing JavaScript Frames


### PR DESCRIPTION
Reference: https://github.com/clinicjs/node-clinic-flame/issues/171.

I haven't found an valid approach to pipe between a non-nodejs process. To summarize the problem:

When no kernel-tracing:

- Root process spawn a new Node.js process
- The communication happens using a new `fd` (created using the `stdio` option).

When kernel-tracing:

- Root process spawn a non-nodejs process that spawn a nodejs process (nodejs -> linux_perf -> nodejs)
- So, the communication between the root process and nodejs doesn't work.

The best option so far is improving the UX by throwing an error when both options are used together, instead quitting silently