### PR TITLE
[doc] add hint for pwsh users

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,12 @@ Pass custom arguments to node:
 0x -- node --zero-fill-buffers my-app.js
 ```
 
+> for pwsh users, switch to CMD at first or run with `npx` 
+> 
+```
+npx 0x -o my-app.js
+```
+
 ## Generating
 
 When ready to generate a flamegraph, send a SIGINT or a SIGTERM.


### PR DESCRIPTION
* `0x` will be recognized as "Integer literals" in windows pwsh, so we need a more cross-platform way
* https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_numeric_literals?view=powershell-7.2

### :scroll: Example code
```bash
#pwsh
PS > 0x
0
PS > npx 0x

  0x 5.4.1

  0x [flags] -- node [nodeFlags] script.js [scriptFlags]
#cmd
PS C:\Users\IITII> cmd
Microsoft Windows [版本 10.0.19044.2006]
(c) Microsoft Corporation。保留所有权利。

CMD > 0x

  0x 5.4.1

  0x [flags] -- node [nodeFlags] script.js [scriptFlags]
``` 