### PR TITLE
fix: node v20 complains of invalid arguments

### DIFF
--- a/lib/preload/soft-exit.js
+++ b/lib/preload/soft-exit.js
@@ -1,4 +1,4 @@
 'use strict'
 
-process.on('SIGINT', process.exit)
-process.on('SIGTERM', process.exit)
+process.on('SIGINT', () => process.exit())
+process.on('SIGTERM', () => process.exit())


### PR DESCRIPTION
0x didn't work for me when using node v20 because calling process.exit with invalid arguments will throw an exception