### PR TITLE
fix/nodejs-21.7.0

### DIFF
--- a/platform/v8.js
+++ b/platform/v8.js
@@ -73,7 +73,7 @@ async function v8 (args) {
   let onsoftexit = softClose
 
   for (let i = 0; i < SOFT_EXIT_SIGNALS.length; i++) {
-    process.once(SOFT_EXIT_SIGNALS[i], onsoftexit)
+    process.on(SOFT_EXIT_SIGNALS[i], onsoftexit)
   }
 
   process.on('exit', forceClose)


### PR DESCRIPTION
Reports aren't being generated on Node.js >= 21.7.0. Upon hitting ctrl+c, the process exits immediately. I experienced the problem on 22.6.0 as well.

Coincidentally, I detected the same [issue on clinic.js](https://github.com/clinicjs/node-clinic/issues/480).

It seems for some reason SIGINT is being received twice and its only caught the first time due to the `once`. I see nothing relevant on the [changelog](https://github.com/nodejs/node/releases/tag/v21.7.0) for 21.7.0.

The `once` -> `on` change should be safe since the handler is being short circuited [here](https://github.com/davidmarkclements/0x/blob/master/platform/v8.js#L53).