### PR TITLE
Allow to pass env variables and provide way to access to child process

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,6 +8,10 @@ The `opts` argument is an object, with the following properties:
 
 Pass the arguments that the spawned Node process should receive. 
 
+#### `env` (object)
+
+Pass the environment variables that the spawned Node process should receive. 
+
 #### `workingDir` (string)
 
 The base directory where profile folders will be placed. 
@@ -82,6 +86,10 @@ modified array to change the output.
 Called with the exit code when the observed process exits.
 
 Default: ()=>{} (noop)
+
+#### `onProcessStart` (function)
+
+Called after the node child process is spwaned.
 
 #### `status` (function)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,27 @@
+import {ChildProcess} from 'child_process'
+
+export = zeroEks;
+
+declare type Args = {
+    argv: string[],
+    workingDir?: string,
+    pathToNodeBinary?: string,
+    name?: string,
+    onPort?: string,
+    title?: string,
+    visualizeOnly?: string,
+    collectOnly?: boolean,
+    collectDelay?: number,
+    mapFrames?: (frames: any, profiler: any) => Array | false,
+    onProcessExit?: () => void,
+    status?: (msg: any) => void,
+    kernelTracing?: boolean,
+    outputDir?: string,
+    outputHtml?: string,
+    treeDebug?: boolean,
+    kernelTracingDebug?: boolean,
+    env?: Record<string, string>,
+    onProcessStart?: (process: ChildProcess) => void
+}
+
+declare function zeroEks(args: Args): Promise<string>;

--- a/platform/linux.js
+++ b/platform/linux.js
@@ -52,7 +52,8 @@ function linux (args, sudo, cb) {
     '--perf-basic-prof',
     '-r', path.join(__dirname, '..', 'lib', 'preload', 'soft-exit.js')
   ].filter(Boolean).concat(args.argv), {
-    stdio: ['ignore', 'inherit', 'inherit', 'ignore', 'ignore', 'pipe']
+    stdio: ['ignore', 'inherit', 'inherit', 'ignore', 'ignore', 'pipe'],
+    env: args.env
   }).on('exit', function (code) {
     args.onProcessExit(code)
     if (code !== null && code !== 0 && code !== 143 && code !== 130) {
@@ -62,6 +63,8 @@ function linux (args, sudo, cb) {
     }
     filterInternalFunctions(perfdat)
   })
+
+  if (args.onProcessStart) args.onProcessStart(proc)
 
   const folder = getTargetFolder({ outputDir, workingDir, name, pid: proc.pid })
 

--- a/platform/v8.js
+++ b/platform/v8.js
@@ -33,8 +33,11 @@ async function v8 (args) {
     '-r', path.join(__dirname, '..', 'lib', 'preload', 'soft-exit'),
     ...(onPort ? ['-r', path.join(__dirname, '..', 'lib', 'preload', 'detect-port.js')] : [])
   ].concat(args.argv), {
-    stdio: ['inherit', 'pipe', 'inherit', 'pipe', 'ignore', 'pipe']
+    stdio: ['inherit', 'pipe', 'inherit', 'pipe', 'ignore', 'pipe'],
+    env: args.env
   })
+
+  if (args.onProcessStart) args.onProcessStart(proc)
 
   // Isolate log is created before command is executed
   // Add pid to original args object so if command errors, external handlers can clean up

--- a/schema.json
+++ b/schema.json
@@ -113,7 +113,7 @@
     "collectDelay": {
       "type": "number"
     },
-     "kernelTracing": {
+    "kernelTracing": {
       "type": "boolean"
     },
     "kernel-tracing": {
@@ -136,6 +136,11 @@
       "type": "array",
       "items": {}
     },
-    "onProcessExit": {}
+    "env": {
+      "type": "object",
+      "properties": {}
+    },
+    "onProcessExit": {},
+    "onProcessStart": {}
   }
 }


### PR DESCRIPTION
Heya, I ran into several problems while wanting to make use of this awesome project. ❤️ 

1. No type definitions where present
2. You couldn't pass environment variables to the child process
3. There was no way to access the underlying child process

To explain myself more, I'm running automated load tests and wanted to generate flame-graphs for these tests. As I'm testing against a express server, the process never exits by itself, so I needed access to the spawned process in order to send the `SIGINT / SIGTERM` signals to it.

Please let me know of any changes you'd like to see.